### PR TITLE
Update index.md

### DIFF
--- a/docs/03-node-operators/08-public-nodes/index.md
+++ b/docs/03-node-operators/08-public-nodes/index.md
@@ -47,4 +47,4 @@ curl https://public-node.rsk.co \
 > Note that [Rootstock public nodes](/node-operators/public-nodes/)
 > do not expose WebSockets, they are HTTP only.
 > To work around this, you may either run your own Rootstock node,
-> or use a third-party node provider, such as [Getblock](https://getblock.io/nodes/rsk/) or [NowNodes](https://nownodes.io/nodes/rsk).
+> or use a third-party node provider, such as [Getblock](https://getblock.io/nodes/rsk/), [NowNodes](https://nownodes.io/nodes/rsk) or [dRPC](https://drpc.org/chainlist/rootstock?utm_source=docs&utm_medium=rootstock)


### PR DESCRIPTION
Added dRPC as third-party provider.

dRPC provides Rootstock RPC endpoints for Mainnet and Testnets including Websockets.