### PR TITLE
fix: rpc api mainnet url

### DIFF
--- a/docs/02-developers/02-requirements/index.md
+++ b/docs/02-developers/02-requirements/index.md
@@ -38,7 +38,7 @@ Fill these values to connect to the Rootstock Mainnet or Testnet.
     </tr>
     <tr>
       <td>RPC URL</td>
-      <td>https://rpc.rootstock.io/{YOUR_APIKEY}</td>
+      <td>https://rpc.mainnet.rootstock.io/{YOUR_APIKEY}</td>
       <td>https://rpc.testnet.rootstock.io/{YOUR_APIKEY}</td>
     </tr>
     <tr>

--- a/docs/02-developers/05-smart-contracts/02-hardhat/configure-hardhat-rootstock.md
+++ b/docs/02-developers/05-smart-contracts/02-hardhat/configure-hardhat-rootstock.md
@@ -51,7 +51,7 @@ To configure your `rskMainnet` and `rskTestnet` private keys, you'll need to upd
     solidity: "0.8.20",
     networks: {
       rskMainnet: {
-        url: "https://rpc.rootstock.io/{YOUR_APIKEY}",
+        url: "https://rpc.mainnet.rootstock.io/{YOUR_APIKEY}",
         chainId: 30,
         gasPrice: 60000000,
         accounts: [process.env.ROOTSTOCK_MAINNET_PRIVATE_KEY]

--- a/docs/05-dev-tools/wallets/metamask.md
+++ b/docs/05-dev-tools/wallets/metamask.md
@@ -44,7 +44,7 @@ Visit the [metamask-landing.rifos.org](https://metamask-landing.rifos.org/) tool
     </tr>
     <tr>
       <td>RPC URL</td>
-      <td>https://rpc.rootstock.io/{YOUR_APIKEY}</td>
+      <td>https://rpc.mainnet.rootstock.io/{YOUR_APIKEY}</td>
       <td>https://rpc.testnet.rootstock.io/{YOUR_APIKEY}</td>
     </tr>
     <tr>


### PR DESCRIPTION
Fixes the RPC API  URLs - on mainnet - being displayed on the portal.

From:
https://rpc.rootstock.io/{{API KEY}}

To:
https://rpc.mainnet.rootstock.io/{{API KEY}}