### PR TITLE
Update to use public nodes in metamask

### DIFF
--- a/docs/05-dev-tools/wallets/metamask.md
+++ b/docs/05-dev-tools/wallets/metamask.md
@@ -44,8 +44,8 @@ Visit the [metamask-landing.rifos.org](https://metamask-landing.rifos.org/) tool
     </tr>
     <tr>
       <td>RPC URL</td>
-      <td>https://rpc.mainnet.rootstock.io/{YOUR_APIKEY}</td>
-      <td>https://rpc.testnet.rootstock.io/{YOUR_APIKEY}</td>
+      <td>https://public-node.rsk.co</td>
+      <td>https://public-node.testnet.rsk.co</td>
     </tr>
     <tr>
       <td>ChainID</td>


### PR DESCRIPTION
## What
- Removed rpc api reference in metamask page

## Why
- Docs Maintenance

## Refs
- [Task](https://rsklabs.atlassian.net/browse/DV-354?atlOrigin=eyJpIjoiZDA1ODg3NzZiZDg2NDNiMmJmNzk1OGRiNGM1NWM2YmQiLCJwIjoiaiJ9)