### PR TITLE
addresses spelling corrected from addressess to addresses

### DIFF
--- a/docs/01-concepts/account-based-addresses.md
+++ b/docs/01-concepts/account-based-addresses.md
@@ -9,7 +9,7 @@ description: "EIP-1191 chainId is used in Rootstock addresses as a checksum. m/4
 Rootstock Addresses incorporate an optional blockchain identifier (also known as `chainId`). If the `chainId` is not present, it is assumed the address refers to the Rootstock main network.
 
 :::info[Info]
-See [contract addresses](/developers/smart-contracts/contract-addresses) for the list of contract addressess on Rootstock or [how to verify address ownership](/developers/smart-contracts/verify-address-ownership/).
+See [contract addresses](/developers/smart-contracts/contract-addresses) for the list of contract addresses on Rootstock or [how to verify address ownership](/developers/smart-contracts/verify-address-ownership/).
 :::
 
 ## How to get an address


### PR DESCRIPTION
In [account-based-addresses](https://dev.rootstock.io/concepts/account-based-addresses/) very small typo corrected!

![image](https://github.com/user-attachments/assets/0b06e5e2-a3f3-44ca-9129-ed6035c62c65)