### PR TITLE
Update metamask.mdx

### DIFF
--- a/docs/05-dev-tools/wallets/metamask.mdx
+++ b/docs/05-dev-tools/wallets/metamask.mdx
@@ -98,7 +98,7 @@ In this guide, you will learn about the different ways to set up and connect to 
     <tr>
       <td>RPC URL</td>
       <td>https://public-node.rsk.co</td>
-      <td>https://public-node.testnet.rsk.co</td>
+      <td>https://rpc.testnet.rootstock.io/&lt;your-api-key&gt;</td>
     </tr>
     <tr>
       <td>ChainID</td>


### PR DESCRIPTION
public node url is not available anymore. found this issue at eth global bankok. 

To reflect the latest url based on https://dev.rootstock.io/developers/rpc-api/rootstock/methods/
