### PR TITLE
Fix accessibility touch target size in Card component

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -36,7 +36,7 @@ export default function Card({index, title, description, list, color = "orange",
             <ul className={`mb-0 mt-auto`}>
               {list.map((item, idx) => (
                 <li key={idx}>
-                  <Link href={item.href} target={item.target} className={`fw-bold`}>
+                  <Link href={item.href} target={item.target} className={`fw-bold py-4`}>
                     {item.title}
                   </Link>
                 </li>

--- a/src/components/Card/styles.module.scss
+++ b/src/components/Card/styles.module.scss
@@ -8,6 +8,6 @@
     }
   }
   li + li {
-    margin-top: 4px;
+    margin-top: 8px;
   }
 }


### PR DESCRIPTION
## Description

* Update links size and margin in the Card component list to fix accessibility touch target size issue

## Screenshots/GIFs

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/7d2da3ff-f422-40ef-8984-267d701e4368">

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.
