### PR TITLE
Fix getblock text in wrong position

### DIFF
--- a/docs/01-concepts/glossary.md
+++ b/docs/01-concepts/glossary.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1.5
-title: Rootstock Glossary | Key Terms and Definitions
-sidebar_label: Rootstock Glossary
+title: Glossary | Key Terms and Definitions
+sidebar_label: Glossary
 tags: [rsk, rootstock, developer tools, courses, guides, tutorials, glossary]
 description: "This glossary contains key terms and definitions to help you better understand the technologies and concepts related to Rootstock."
 ---

--- a/docs/05-dev-tools/node-rpc/rpc-api.md
+++ b/docs/05-dev-tools/node-rpc/rpc-api.md
@@ -31,7 +31,7 @@ JSON-RPC is a remote procedure call protocol encoded in JSON. It’s simple, sta
 
  To learn more about the Rootstock RPC API, including how to use it, features,  click the button below:
  
-<Button href="https://dev.rootstock.io/developers/rpc-api/rootstock/" align="left">Rootstock getBlock Website</Button>
+<Button href="https://dev.rootstock.io/developers/rpc-api/rootstock/" align="left">Rootstock RPC API Guide</Button>
 
 :::
 


### PR DESCRIPTION
## Title
*Fix getblock text in wrong position

## Description

* I removed the text `Rootstock getblock website` in a wrong position in a button directed to Rootstock RPC API guide.

## Screenshots/GIFs

* N/A

## Testing

* N/A

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.

## Refs

* N/A