### PR TITLE
Update docs for 6.5.0

### DIFF
--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -89,7 +89,8 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation.
+There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
+not valid anymore.
 
 You can see this behavior in the following example, where a call for `eth_estimateGas` on a transaction that would be executed from an address without enough balance.
 

--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -89,7 +89,19 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
+:::info[Info]
+
+**Prior to Arrowhead 6.5.0**, there was a difference in Rootstock compared to Ethereum:
+
+- If one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction
+- On Ethereum, the node would return an error instead of the gas estimation. 
+
+**Starting with Arrowhead 6.5.0:**
+
+- Rootstock will behave same way as Ethereum's behavior for simulated transaction failures.
+- If a simulated transaction step fails, the node will now return an error, mirroring Ethereum's response.
+
+:::
 
 You can see this behavior in the following example, where a call for `eth_estimateGas` on a transaction that would be executed from an address without enough balance.
 

--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -89,8 +89,7 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
-not valid anymore.
+Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
 
 You can see this behavior in the following example, where a call for `eth_estimateGas` on a transaction that would be executed from an address without enough balance.
 

--- a/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
+++ b/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
@@ -199,7 +199,8 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation.
+There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
+not valid anymore.
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
+++ b/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
@@ -199,8 +199,7 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
-not valid anymore.
+Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
+++ b/docs/02-developers/07-rpc-api/02-rootstock/02-methods.md
@@ -199,7 +199,19 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
+:::info[Info]
+
+**Prior to Arrowhead 6.5.0**, there was a difference in Rootstock compared to Ethereum:
+
+- If one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction
+- On Ethereum, the node would return an error instead of the gas estimation. 
+
+**Starting with Arrowhead 6.5.0:**
+
+- Rootstock will behave same way as Ethereum's behavior for simulated transaction failures.
+- If a simulated transaction step fails, the node will now return an error, mirroring Ethereum's response.
+
+:::
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/03-node-operators/03-json-rpc/01-methods.md
+++ b/docs/03-node-operators/03-json-rpc/01-methods.md
@@ -1089,7 +1089,8 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation.
+There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
+not valid anymore.
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/03-node-operators/03-json-rpc/01-methods.md
+++ b/docs/03-node-operators/03-json-rpc/01-methods.md
@@ -1089,7 +1089,19 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
+:::info[Info]
+
+**Prior to Arrowhead 6.5.0**, there was a difference in Rootstock compared to Ethereum:
+
+- If one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction
+- On Ethereum, the node would return an error instead of the gas estimation. 
+
+**Starting with Arrowhead 6.5.0:**
+
+- Rootstock will behave same way as Ethereum's behavior for simulated transaction failures.
+- If a simulated transaction step fails, the node will now return an error, mirroring Ethereum's response.
+
+:::
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/03-node-operators/03-json-rpc/01-methods.md
+++ b/docs/03-node-operators/03-json-rpc/01-methods.md
@@ -1089,8 +1089,7 @@ Note that when `eth_estimateGas` is called, the node simulates the transaction e
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-There is a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node will return the gas estimation needed for the transaction, while on Ethereum, the node will return an error instead of the gas estimation. Starting with Arrowhead 6.4.0 this is
-not valid anymore.
+Until `Arrowhead 6.5.0`, there was a difference in Rootstock compared to Ethereum, and it is that if one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction, while on Ethereum, the node would return an error instead of the gas estimation. Starting with `Arrowhead 6.5.0` this is not valid anymore, Rootstock will behave same way as Ethereum, returning an error if one of the steps of the simulated transaction fails.
 
 You can see this behavior on the following example, where we call `eth_estimateGas` for a transaction that would be executed from an address without enough balance.
 

--- a/docs/03-node-operators/03-json-rpc/05-management-api-methods.md
+++ b/docs/03-node-operators/03-json-rpc/05-management-api-methods.md
@@ -32,8 +32,8 @@ description: "The JSON-RPC methods supported by Rootstock nodes."
 | `debug_startGoTrace` | NO | |
 | `debug_stopGoTrace` | NO | |
 | `debug_traceBlock` | NO | |
-| `debug_traceBlockByNumber` | NO | |
-| `debug_traceBlockByHash` | NO | |
+| `debug_traceBlockByNumber` | YES | |
+| `debug_traceBlockByHash` | YES | |
 | `debug_traceBlockFromFile` | NO | |
 | `debug_traceTransaction` | YES | |
 | `debug_vmodule` | NO | |


### PR DESCRIPTION
## Title

* Update methods documentation with changes introduced in ARROWHEAD 6.5.0

## Description

* Method `eth_estimateGas` was updated to increase Ethereum compatibility, so the documentation was updated to highlight the changes after 6.5.0.
* Method `debug_traceBlockByNumber` was added in 6.5.0, so the documentation should be updated to showcase that.
* Method `debug_traceBlockByHash` was not added to the doc previously, so we added it now.

## Screenshots/GIFs

* N/A

## Testing

* N/A

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.

## Refs

* [ARROWHEAD 6.5.0](https://github.com/rsksmart/rskj/releases/tag/ARROWHEAD-6.5.0)