### PR TITLE
Java 21 fix

### DIFF
--- a/changelog/2024-11-05-introducing-arrowhead-6.4.0.md
+++ b/changelog/2024-11-05-introducing-arrowhead-6.4.0.md
@@ -7,6 +7,6 @@ url: https://blog.rootstock.io/noticia/arrowhead-6-4-0-introducing-fiat-stable-m
 
 **Summary**: 
 
-The Rootstock community is pleased to announce the release of the latest version of the RSKj client, which is now available in the [RSKj GitHub repository](https://github.com/rsksmart/rskj/releases/tag/ARROWHEAD-6.4.0). This update introduces the **fiat-stable minimum gas price feature** (disabled by default), enabling mining pools to automatically adjust their minimum gas price configuration based on the price of Bitcoin. Additionally, it includes JSON-RPC interface improvements and dependency upgrades, now supporting **Java 21 LTS**.
+The Rootstock community is pleased to announce the release of the latest version of the RSKj client, which is now available in the [RSKj GitHub repository](https://github.com/rsksmart/rskj/releases/tag/ARROWHEAD-6.4.0). This update introduces the **fiat-stable minimum gas price feature** (disabled by default), enabling mining pools to automatically adjust their minimum gas price configuration based on the price of Bitcoin. Additionally, it includes JSON-RPC interface improvements and dependency upgrades.
 
 > Note that this upgrade is optional, however it is strongly recommended that users update their nodes to the latest version to benefit from enhanced performance and security.

--- a/docs/03-node-operators/04-setup/02-installation/java.md
+++ b/docs/03-node-operators/04-setup/02-installation/java.md
@@ -136,7 +136,7 @@ After starting the node, if there's no output, this means it's running correctly
 Output:
 
 ```shell
-{"jsonrpc":"2.0","id":67,"result":"RskJ/6.5.0/Mac OS X/Java21/ARROWHEAD-e016b25"}
+{"jsonrpc":"2.0","id":67,"result":"RskJ/6.6.0/Mac OS X/Java17/SNAPSHOT-95a8f1ab84"}
 ```
 
 2. To check the block number:


### PR DESCRIPTION
## Title
* Removing Java 21 references

## Description

* Java 21 is not supported by the node, so we're removing it from the docs.

## Screenshots/GIFs

* N/A

## Testing

* N/A

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.

## Refs

* N/A