### PR TITLE
📖 fix: update PRIVATE_KEY to WALLET_PRIVATE_KEY in Documentation

### DIFF
--- a/docs/02-developers/04-quickstart/hardhat.md
+++ b/docs/02-developers/04-quickstart/hardhat.md
@@ -82,7 +82,7 @@ There are two ways to obtain RPC URLs:
 
 After obtaining the RPC URLs, create a file named `.env` in your project's root directory (important: this file should not be committed to version control). Add the necessary environment variables to the `.env` file:
 ```
-PRIVATE_KEY= Your private key (e.g., from your Metamask account details).
+WALLET_PRIVATE_KEY= Your private key (e.g., from your Metamask account details).
 RSK_MAINNET_RPC_URL= The RPC URL for the Rootstock mainnet.
 RSK_TESTNET_RPC_URL= The RPC URL for the Rootstock testnet.
 ```


### PR DESCRIPTION
This PR updates the Rootstock Scaffold documentation to replace PRIVATE_KEY with WALLET_PRIVATE_KEY to match the actual variable used in the Hardhat configuration.

Changes Made:
Updated .env.example (if applicable)

Updated README.md / HARDHAT.md with correct environment variable

Ensured consistency across documentation

Why This Fix?
The existing documentation instructs users to set PRIVATE_KEY, but the scaffold project actually uses WALLET_PRIVATE_KEY. This fix prevents potential setup errors for developers following the documentation.