### PR TITLE
uniformed network names in hardhat.config.ts with later usage

### DIFF
--- a/docs/04-resources/05-port-to-rootstock/ethereum-dapp.md
+++ b/docs/04-resources/05-port-to-rootstock/ethereum-dapp.md
@@ -212,13 +212,13 @@ const config: HardhatUserConfig = {
 
   networks: {
     // Mainnet configuration
-    mainnet: {
+    rskMainnet: {
       url: "https://rpc.mainnet.rootstock.io/<API-KEY>",
       accounts: [process.env.PRIVATE_KEY],
     },
 
     // Testnet configuration
-    testnet: {
+    rskTestnet: {
       url: "https://rpc.testnet.rootstock.io/<API-KEY>",
       accounts: [process.env.PRIVATE_KEY],
     },


### PR DESCRIPTION
Small fix. In the previous version, the deploy network resulted non-existing if tutorial was followed step by step 
See https://github.com/rsksmart/devportal/issues/296