### PR TITLE
Improving the explanation about differences in gas costs.

### DIFF
--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -147,14 +147,14 @@ Response on Ethereum:
 }
 ```
 
-#### Major Differences in Gas Costs
+:::info[Major Differences in Gas Costs]
 
-Regarding the differences in gas costs, we have identified that the opcodes with significant variations are `SLOAD` and `SSTORE`.
+We have identified that the opcodes with significant variations are `SLOAD` and `SSTORE`.
 Additionally, certain calls (such as `DELEGATECALL` and `STATICCALL`) that utilize these opcodes during an internal call will result in differences in the overall gas cost calculation for the transaction.
 
-These discrepancies are primarily due to an Ethereum Improvement Proposal (EIP) that has been implemented in Ethereum but not yet in Rootstock.
-Specifically, this is [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929). We are aware of this difference, and our team plans to address and implement this in future releases.
+These discrepancies are primarily due to [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) that has been implemented in Ethereum but not yet in Rootstock. The team is aware of this difference and intend to implement this in future releases.
 
+:::
 
 ## EVM Compatible Smart Contracts
 

--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -94,13 +94,13 @@ These discrepancies are primarily due to [EIP-2929](https://eips.ethereum.org/EI
 
 :::
 
-#### Estimate Gas Behaviour on Rootstock
+#### Eth Estimate Gas Behaviour on Rootstock
 
-Note that when `eth_estimateGas` is called, the node simulates the transaction execution without broadcasting it to the network.
+When `eth_estimateGas` is called, the node simulates the transaction execution without broadcasting it to the network.
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
 
-:::info[Info]
+:::info[Starting with Arrowhead 6.5.0]
 
 **Prior to Arrowhead 6.5.0**, there was a difference in Rootstock compared to Ethereum:
 
@@ -114,7 +114,7 @@ During the simulation, the method calculates the exact amount of gas that would 
 
 :::
 
-You can see this behavior in the following example, where a call for `eth_estimateGas` on a transaction that would be executed from an address without enough balance.
+This behavior can be seen in the following example, where a call for `eth_estimateGas` on a transaction that would be executed from an address without enough balance.
 
 Example:
 

--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -85,6 +85,17 @@ However, the price of each op-code (measured in units known as gas) is different
 Further to that, gas units are multiplied by gas price to calculate the transaction cost.
 Since Rootstock’s gas price is denominated in RBTC and Ethereum’s gas price is denominated in Ether, there is another difference between gas prices on Rootstock and Ethereum.
 
+:::info[Update on Gas Cost Differences]
+
+We have identified that the opcodes with significant variations are `SLOAD` and `SSTORE`.
+Additionally, certain calls (such as `DELEGATECALL` and `STATICCALL`) that utilize these opcodes during an internal call will result in differences in the overall gas cost calculation for the transaction.
+
+These discrepancies are primarily due to [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) that has been implemented in Ethereum but not yet in Rootstock. The team is aware of this difference and intend to implement this in future releases.
+
+:::
+
+#### Estimate Gas Behaviour on Rootstock
+
 Note that when `eth_estimateGas` is called, the node simulates the transaction execution without broadcasting it to the network.
 The simulation runs through the entire transaction process as if it were being executed, including checking for sufficient balance, contract code execution, etc.
 During the simulation, the method calculates the exact amount of gas that would be consumed by the transaction if it were to be executed on the blockchain. The estimated gas amount is returned, helping users set an appropriate gas limit for the actual transaction.
@@ -146,15 +157,6 @@ Response on Ethereum:
     }
 }
 ```
-
-:::info[Major Differences in Gas Costs]
-
-We have identified that the opcodes with significant variations are `SLOAD` and `SSTORE`.
-Additionally, certain calls (such as `DELEGATECALL` and `STATICCALL`) that utilize these opcodes during an internal call will result in differences in the overall gas cost calculation for the transaction.
-
-These discrepancies are primarily due to [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) that has been implemented in Ethereum but not yet in Rootstock. The team is aware of this difference and intend to implement this in future releases.
-
-:::
 
 ## EVM Compatible Smart Contracts
 

--- a/docs/02-developers/03-blockchain-essentials/02-overview/index.md
+++ b/docs/02-developers/03-blockchain-essentials/02-overview/index.md
@@ -94,7 +94,7 @@ During the simulation, the method calculates the exact amount of gas that would 
 **Prior to Arrowhead 6.5.0**, there was a difference in Rootstock compared to Ethereum:
 
 - If one of the steps of the simulated transaction fails, the node would return the gas estimation needed for the transaction
-- On Ethereum, the node would return an error instead of the gas estimation. 
+- On Ethereum, the node would return an error instead of the gas estimation.
 
 **Starting with Arrowhead 6.5.0:**
 
@@ -146,6 +146,15 @@ Response on Ethereum:
     }
 }
 ```
+
+#### Major Differences in Gas Costs
+
+Regarding the differences in gas costs, we have identified that the opcodes with significant variations are `SLOAD` and `SSTORE`.
+Additionally, certain calls (such as `DELEGATECALL` and `STATICCALL`) that utilize these opcodes during an internal call will result in differences in the overall gas cost calculation for the transaction.
+
+These discrepancies are primarily due to an Ethereum Improvement Proposal (EIP) that has been implemented in Ethereum but not yet in Rootstock.
+Specifically, this is [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929). We are aware of this difference, and our team plans to address and implement this in future releases.
+
 
 ## EVM Compatible Smart Contracts
 


### PR DESCRIPTION
## Title
Adding a section on Major Differences in Gas Costs in the Blockchain Overview. Mainly to explain which opcodes have this differences so partners can refer and add a link to this message.

## Description

* The update aims to enhance clarity, readability, and accuracy of information regarding gas cost differences between Rootstock and Ethereum. Main focusing in each opcodes has these differences.

## Screenshots/GIFs

* N/A
* 
## Testing
* Yes, I have tested locally with yarn.

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.

## Refs

* Related links to issues, tickets, etc.