### PR TITLE
docs: Updated dead links

### DIFF
--- a/docs/05-dev-tools/dev-environments/foundry.md
+++ b/docs/05-dev-tools/dev-environments/foundry.md
@@ -53,5 +53,5 @@ The debugger terminal is divided into four quadrants:
 - [Foundry Project Layout](https://book.getfoundry.sh/projects/project-layout)
 - [RPC Calls Using Cast](https://book.getfoundry.sh/cast/)
 - [Foundry Configurations](https://book.getfoundry.sh/config/)
-- [Solidity Scripting](https://book.getfoundry.sh/tutorials/solidity-scripting)
-- [Deploy Smart Contracts To Deterministic Addresses](https://book.getfoundry.sh/tutorials/create2-tutorial)
+- [Solidity Scripting](https://book.getfoundry.sh/guides/scripting-with-solidity)
+- [Deploy Smart Contracts To Deterministic Addresses](https://book.getfoundry.sh/guides/deterministic-deployments-using-create2)


### PR DESCRIPTION
## Description

Replaced outdated links `Foundry` in `docs/05-dev-tools/dev-environments/foundry.md`. These changes ensure users are directed to the current and working sections of the Foundry book.

## Testing

Manually verified that both updated URLs are accessible and correctly point to the intended guides.

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.
