### PR TITLE
fix:Update rootstock-vyper.md

### DIFF
--- a/docs/02-developers/04-quickstart/rootstock-vyper.md
+++ b/docs/02-developers/04-quickstart/rootstock-vyper.md
@@ -295,5 +295,5 @@ ModuleNotFoundError: No module named 'web3'
 
 
 :::info[Credit]
-This project's boilerplate originates from the [Cyfrin Updraft @cyfrinupdraft](https://updraft.cyfrin.io/courses/intermediate-python-vyper-smart-contract-development) Python and Viper Starter Kit, developed by [@EdwinLiavaa](https://github.com/EdwinLiavaa) during the [Rootstock Hacktivator](/resources/contribute/hacktivator/).
+This project's boilerplate originates from the [Cyfrin Updraft @cyfrinupdraft](https://updraft.cyfrin.io/courses/intermediate-python-vyper-smart-contract-development) Python and Vyper Starter Kit, developed by [@EdwinLiavaa](https://github.com/EdwinLiavaa) during the [Rootstock Hacktivator](/resources/contribute/hacktivator/).
 :::


### PR DESCRIPTION
## Title
Fixed the small typo

## Description
in the [rootstock-vyper](https://dev.rootstock.io/developers/quickstart/rootstock-vyper/) file fixed the small typo from **"Viper"** to **"Vyper"**
## Screenshots/GIFs

<img width="756" alt="image" src="https://github.com/user-attachments/assets/a8b7aec0-75a8-4bd1-b947-16d809a299e1" />


## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.