### PR TITLE
Temporary fix for broken results in search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -295,6 +295,9 @@ const config = {
 
         // Optional: see doc section below
         contextualSearch: false,
+        searchParameters: {
+          facetFilters: ['language:en'],
+        },
 
       }
     }),

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -182,7 +182,7 @@ function SearchPageContentInternal () {
   // respect settings from the theme config for facets
   const disjunctiveFacets = contextualSearch
     ? ['language', 'docusaurus_tag']
-    : []
+    : ['language'] //TODO: remove this when contextualSearch fixed
   const algoliaClient = liteClient(appId, apiKey)
   const algoliaHelper = algoliaSearchHelper(algoliaClient, indexName, {
     hitsPerPage: 15,
@@ -271,6 +271,8 @@ function SearchPageContentInternal () {
         description: 'The search page title for empty query',
       })
   const makeSearch = useEvent((page = 0) => {
+    algoliaHelper.addDisjunctiveFacetRefinement('language', currentLocale) //TODO: remove this when contextualSearch fixed
+
     if (contextualSearch) {
       algoliaHelper.addDisjunctiveFacetRefinement('docusaurus_tag', 'default')
       algoliaHelper.addDisjunctiveFacetRefinement('language', currentLocale)


### PR DESCRIPTION
## Title

* Temporary fix for broken results in search. Show results only in English 

## Description

* Add `language` facet filter to Algolia search parameters in docusaurus.config.js.
* Temporary disjunctive refinements for contextualSearch workaround.
* Show results only in English for other languages.

## Screenshots/GIFs

<img width="655" alt="image" src="https://github.com/user-attachments/assets/95c16c73-c62b-4ed2-b3ff-4bb33e84bb1b" />


## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.
