### PR TITLE
Feat/cookbook click tracking

### DIFF
--- a/src/theme/Navbar/AskCookbook/index.js
+++ b/src/theme/Navbar/AskCookbook/index.js
@@ -19,25 +19,29 @@ export default function AskCookbook() {
       if (el && el.shadowRoot) {
         const btn = el.shadowRoot.querySelector("#ask-cookbook-button");
         if (btn) {
-          btn.addEventListener("click", () => {
-            window.dataLayer = window.dataLayer || [];
-            window.dataLayer.push({ event: "askCookbookClick" });
-            console.log("✅ askCookbookClick fired from MutationObserver in React.");
-          });
-          console.log("✅ Listener attached to ask-cookbook button.");
+          // Wait a bit to ensure widget initialization is complete
+          setTimeout(() => {
+            btn.addEventListener("click", () => {
+              window.dataLayer = window.dataLayer || [];
+              window.dataLayer.push({ event: "askCookbookClick" });
+              console.log("✅ askCookbookClick fired after delayed attach.");
+            });
+            console.log("✅ Listener attached to ask-cookbook button after delay.");
+          }, 2000); // You can adjust if needed
+  
           obs.disconnect();
         }
       }
     });
-
+  
     observer.observe(document, {
       childList: true,
       subtree: true
     });
-
+  
     return () => observer.disconnect();
   }, []);
-
+  
   return (
     <BrowserOnly>
       {() => (

--- a/src/theme/Navbar/AskCookbook/index.js
+++ b/src/theme/Navbar/AskCookbook/index.js
@@ -5,17 +5,26 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 const BaseAskCookbook = React.lazy(() =>
   import("@cookbookdev/docsbot/react-fixed")
 );
+
 export default function AskCookbook() {
   const {
-        siteConfig: {customFields},
-      } = useDocusaurusContext();
-      const {keys} = customFields;
-      const COOKBOOK_PUBLIC_API_KEY = keys.cookbook;
+    siteConfig: { customFields },
+  } = useDocusaurusContext();
+  const { keys } = customFields;
+  const COOKBOOK_PUBLIC_API_KEY = keys.cookbook;
+
   return (
     <BrowserOnly>
       {() => (
         <Suspense>
-          <BaseAskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} />
+          <BaseAskCookbook
+            apiKey={COOKBOOK_PUBLIC_API_KEY}
+            onOpen={() => {
+              window.dataLayer = window.dataLayer || [];
+              window.dataLayer.push({ event: "askCookbookClick" });
+              console.log("✅ askCookbookClick event fired from onOpen prop");
+            }}
+          />
         </Suspense>
       )}
     </BrowserOnly>

--- a/src/theme/Navbar/AskCookbook/index.js
+++ b/src/theme/Navbar/AskCookbook/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, Suspense } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 const BaseAskCookbook = React.lazy(() =>
   import("@cookbookdev/docsbot/react-fixed")
@@ -16,32 +16,40 @@ export default function AskCookbook() {
   useEffect(() => {
     const observer = new MutationObserver((mutations, obs) => {
       const el = document.querySelector("ask-cookbook");
-      if (el && el.shadowRoot) {
+      if (el?.shadowRoot) {
         const btn = el.shadowRoot.querySelector("#ask-cookbook-button");
         if (btn) {
-          // Wait a bit to ensure widget initialization is complete
-          setTimeout(() => {
+          // Prevent duplicate listeners
+          if (!btn.dataset.listenerAttached) {
             btn.addEventListener("click", () => {
               window.dataLayer = window.dataLayer || [];
-              window.dataLayer.push({ event: "askCookbookClick" });
-              console.log("✅ askCookbookClick fired after delayed attach.");
+              window.dataLayer.push({
+                event: "askCookbookClick",
+                componentId: "ask-cookbook-button",
+                componentLabel: btn.innerText.trim() || "Ask Cookbook",
+                pageUrl: window.location.href,
+                pagePath: window.location.pathname,
+                pageTitle: document.title,
+                timestamp: new Date().toISOString(),
+              });
+              console.log("✅ askCookbookClick event fired.");
             });
-            console.log("✅ Listener attached to ask-cookbook button after delay.");
-          }, 2000); // You can adjust if needed
-  
+            btn.dataset.listenerAttached = "true";
+            console.log("✅ Listener attached to ask-cookbook button.");
+          }
           obs.disconnect();
         }
       }
     });
-  
+
     observer.observe(document, {
       childList: true,
-      subtree: true
+      subtree: true,
     });
-  
+
     return () => observer.disconnect();
   }, []);
-  
+
   return (
     <BrowserOnly>
       {() => (

--- a/src/theme/Navbar/AskCookbook/index.js
+++ b/src/theme/Navbar/AskCookbook/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React, { useEffect, Suspense } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -13,18 +13,36 @@ export default function AskCookbook() {
   const { keys } = customFields;
   const COOKBOOK_PUBLIC_API_KEY = keys.cookbook;
 
+  useEffect(() => {
+    const observer = new MutationObserver((mutations, obs) => {
+      const el = document.querySelector("ask-cookbook");
+      if (el && el.shadowRoot) {
+        const btn = el.shadowRoot.querySelector("#ask-cookbook-button");
+        if (btn) {
+          btn.addEventListener("click", () => {
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({ event: "askCookbookClick" });
+            console.log("✅ askCookbookClick fired from MutationObserver in React.");
+          });
+          console.log("✅ Listener attached to ask-cookbook button.");
+          obs.disconnect();
+        }
+      }
+    });
+
+    observer.observe(document, {
+      childList: true,
+      subtree: true
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <BrowserOnly>
       {() => (
         <Suspense>
-          <BaseAskCookbook
-            apiKey={COOKBOOK_PUBLIC_API_KEY}
-            onOpen={() => {
-              window.dataLayer = window.dataLayer || [];
-              window.dataLayer.push({ event: "askCookbookClick" });
-              console.log("✅ askCookbookClick event fired from onOpen prop");
-            }}
-          />
+          <BaseAskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} />
         </Suspense>
       )}
     </BrowserOnly>


### PR DESCRIPTION
## Title

Add askCookbookClick analytics event tracking for Cookbook widget


## Description

This PR introduces analytics tracking for user interactions with the Ask Cookbook widget on the documentation site.
Specifically:

Attaches a click event listener to the Cookbook button rendered inside a Shadow DOM.
Pushes a custom askCookbookClick event to the dataLayer for analytics (e.g., Google Tag Manager).
Enriches the event payload with useful metadata, including:

- componentId
- componentLabel
- pageUrl
- pagePath
- pageTitle
- timestamp

The purpose of this change is to help better understand usage of the Cookbook tool. 

## Screenshots/GIFs

* Include any relevant screenshots or GIFs to visually demonstrate the changes.

## Testing

- Preview deploy to simulate production behavior.
- Verified that the Cookbook button renders properly via Shadow DOM.
- Confirmed the askCookbookClick event is pushed to window.dataLayer upon clicking the button.
- Checked console logs and validated GTM trigger using Tag Assistant preview mode.

## Checklist

- [ x] I have read and understood the contributing guidelines.
- [x ] I have followed the style guide and formatting guidelines.
- [ x] I have added appropriate comments to explain the changes.
- [ x] I have tested my changes thoroughly.

## Refs

* [Preview link](https://devportal-rootstock-9q93dr3cv-iov-labs-mkt.vercel.app/)
* Cookbook Docs: https://docs.cookbook.dev/