### PR TITLE
fix: correct spelling mistakes in documentation

### DIFF
--- a/docs/02-developers/05-smart-contracts/02-hardhat/create-hardhat-project.md
+++ b/docs/02-developers/05-smart-contracts/02-hardhat/create-hardhat-project.md
@@ -24,7 +24,7 @@ Run the following command in the project root.
   npm install
 ```
 
-> The quick start repo already comes pre-installed with hardhat. The `master` branch has the intial setup and barebones project and the `feat/complete` branch has the complete state of the hardhat project. You can view the diff in the initial and complete state branches of the repo at any point in time while going through this material. To run the full project, checkout into feat/complete branch, install the dependencies and run the command: `npx http-server`.
+> The quick start repo already comes pre-installed with hardhat. The `master` branch has the initial setup and barebones project and the `feat/complete` branch has the complete state of the hardhat project. You can view the diff in the initial and complete state branches of the repo at any point in time while going through this material. To run the full project, checkout into feat/complete branch, install the dependencies and run the command: `npx http-server`.
 
 ### Verify Hardhat Installation
 

--- a/docs/05-dev-tools/oracles/redstonefinance.md
+++ b/docs/05-dev-tools/oracles/redstonefinance.md
@@ -7,7 +7,7 @@ tags: [Finance, redStone, developer tools, rsk, rootstock, ethereum, Oracles, te
 ---
 
 
-RedStone Finance offers modular, cross-chain Oracle solutions tailored for DeFi applications. With compatibility across EVM and non-EVM ecosystems such as Rootstock, RedStone empowers developers to access accurate, real-time, and customizable data feeds for diverse use cases such as DEX pricing, yield-bearing collaterals, and staking protocols. <Shield label="Mainnet" title="Testnet" tooltip="This is avaiable on both Mainnet and Testnet" color="blue" />
+RedStone Finance offers modular, cross-chain Oracle solutions tailored for DeFi applications. With compatibility across EVM and non-EVM ecosystems such as Rootstock, RedStone empowers developers to access accurate, real-time, and customizable data feeds for diverse use cases such as DEX pricing, yield-bearing collaterals, and staking protocols. <Shield label="Mainnet" title="Testnet" tooltip="This is available on both Mainnet and Testnet" color="blue" />
 
 The system emphasizes scalability, cost-efficiency, and flexibility, leveraging technologies like Arweave for data archiving.
 


### PR DESCRIPTION
- Fix 'intial' → 'initial' in hardhat create project guide
- Fix 'avaiable' → 'available' in RedStone Finance oracle docs

## Title

fix: correct spelling mistakes in documentation


## Description
This PR fixes two spelling errors found in the documentation:
Hardhat Project Guide: Fixed "intial" → "initial" in the create-hardhat-project.md file where it described the master branch setup
RedStone Finance Oracle Docs: Fixed "avaiable" → "available" in the tooltip text for the Shield component
These corrections improve the overall quality and professionalism of the documentation by ensuring proper spelling throughout the codebase.

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.
