### PR TITLE
Update link to RNS service in documentation

### DIFF
--- a/docs/01-concepts/rif-suite/rns/index.md
+++ b/docs/01-concepts/rif-suite/rns/index.md
@@ -13,7 +13,7 @@ RNS provides an architecture which enables the identification of blockchain addr
 <div className="row rif_blue_text">
   <div className="col">
     <div className="rns-index-box">
-      <a href="try-rns">Try the service</a>
+      <a href="https://rns.rifos.org/">Try the service</a>
       <br />
       <br />
       <p>Register a domain in the Testnet, for free.</p>


### PR DESCRIPTION
## Title

Fix broken try-rns link to point to RNS service URL

## Description

Fixed a broken internal link reference by updating it to point to the actual RNS (RIF Name Service) website at https://rns.rifos.org/. The previous link was using an internal reference `try-rns` that didn't resolve to a valid destination.

**Changes made:**
- Updated the "Try the service" link from internal reference `try-rns` to the external URL `https://rns.rifos.org/`

## Screenshots/GIFs
Current state when a person clicks on Try service
<img width="1511" height="847" alt="Screenshot 2026-01-26 at 8 10 04 PM" src="https://github.com/user-attachments/assets/87479693-d2d8-412a-ae69-5679f5ed5753" />

N/A - This is a simple link fix with no visual changes to the documentation layout.

## Testing

- Manually verified the link now correctly navigates to https://rns.rifos.org/
- Confirmed the link opens in the browser and the RNS service page loads successfully
- Ran `yarn build` to ensure no build errors were introduced

## Checklist

- [x] I have read and understood the contributing guidelines.
- [x] I have followed the style guide and formatting guidelines.
- [x] I have added appropriate comments to explain the changes.
- [x] I have tested my changes thoroughly.

## Refs

N/A