### PR TITLE
style: Adjust Markdown header flex properties for layout consistency

### DIFF
--- a/src/scss/components/_markdown-actions.scss
+++ b/src/scss/components/_markdown-actions.scss
@@ -2,7 +2,7 @@
 article .markdown header {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 1rem;
   overflow: visible;
   width: 100%;


### PR DESCRIPTION
Changed the flex-wrap property of the Markdown header from wrap to nowrap. This modification improves the layout by preventing items from wrapping, ensuring a more consistent appearance across different screen sizes.

Related to #467 