### PR TITLE
feat: add tRBTC Faucet shortcut with GA4 click tracking

### DIFF
--- a/docs/04-resources/06-guides/defi-developer-guide/index.md
+++ b/docs/04-resources/06-guides/defi-developer-guide/index.md
@@ -33,10 +33,10 @@ This guide is divided into five main sections, each building on the previous:
 ### 1. [Token Standards & Best Practices](/resources/guides/defi-developer-guide/token-standards)
 Learn how to implement and extend ERC-20, ERC-721, and ERC-4626 tokens on Rootstock. Understand wrapping RBTC (wRBTC), gas optimization, and security considerations specific to token development.
 
-### 2. [Oracle Integration](/resources/guides/defi-developer-guide/oracle-integration)
+### 2. [Oracle Integration](/use-cases/interoperability/oracle-chainlink-mock/)
 Discover how to fetch reliable off-chain data using Chainlink or other oracles. Implement price feeds, randomness (VRF), and secure oracle patterns to protect your protocol from manipulation.
 
-### 3. [Automated Market Makers (AMM) Basics](/resources/guides/defi-developer-guide/amm-basics)
+### 3. [Automated Market Makers (AMM) Basics](/use-cases/interoperability/amm-constant-product/)
 Build a simple constant-product AMM from scratch. Understand liquidity pools, swap mechanics, fees, and slippage. Test your contract with Hardhat and integrate it with a React frontend.
 
 ### 4. [Security Patterns](/resources/guides/defi-developer-guide/security-patterns)

--- a/docs/05-dev-tools/additional-tools/index.mdx
+++ b/docs/05-dev-tools/additional-tools/index.mdx
@@ -6,9 +6,11 @@ description: "General tools to build on Rootstock"
 tags: [hardhat, quick start, developer tools, rsk, rootstock, ethereum, dApps, smart contracts]
 ---
 
+import TrackedLink from '/src/components/TrackedLink';
+
 ## Faucets
 
-* [Rootstock Faucet](https://faucet.rootstock.io/): Get free test RBTC tokens for development and testing.
+* <TrackedLink href="https://faucet.rootstock.io/" event="faucetClick" componentId="additional-tools-faucet-link" componentLabel="Rootstock Faucet">Rootstock Faucet</TrackedLink>: Get free test RBTC tokens for development and testing.
 * [RIF Testnet Faucet](https://faucet.rifos.org/): Obtain free RIF testnet tokens to explore the RIF ecosystem.
 * [Thirdweb Faucet](https://thirdweb.com/rootstock-testnet): Get free test RBTC tokens for development and testing. Not available on FREE plans.
 

--- a/docs/06-use-cases/btcfi-finance-yield/yield-vaults-sdk.md
+++ b/docs/06-use-cases/btcfi-finance-yield/yield-vaults-sdk.md
@@ -80,4 +80,4 @@ The [README full example](https://github.com/rsksmart/vaults-sdk) wires `getAllo
 * Re-read allocator and issuer documentation for **USDRIF** before you expose APY or TVL to end users.
 * [Automation and AI on Rootstock](/use-cases/ai-automation/)
 * [RIF economy and governance](/use-cases/integrate-rif-economy/)
-* [Rootstock Explorer](/dev-tools/explorers/rootstock/)
+* [Rootstock Explorer](/dev-tools/explorers/rootstock-explorer/)

--- a/docs/06-use-cases/onboarding-ux/index.md
+++ b/docs/06-use-cases/onboarding-ux/index.md
@@ -6,7 +6,7 @@ description: "Mastering the tools that make Bitcoin dApps as seamless as Web2."
 tags: [ux, onboarding, rif-relay, rns, account-abstraction, fundamentals]
 ---
 
-Blockchain technology often comes with high friction, such as hard to remember seed phrases, gas fees, and long hexadecimal addresses. Enhancing the UX and Onboarding on Rootstock is about abstracting this complexity. By leveraging core [DevTools](/dev-tools/) compatible with Rootstock such as [Para Wallet](/developers/quickstart/para), [Reown](/developers/quickstart/reown), developers can build applications that feel like standard web apps while retaining the security of Bitcoin.
+Blockchain technology often comes with high friction, such as hard to remember seed phrases, gas fees, and long hexadecimal addresses. Enhancing the UX and Onboarding on Rootstock is about abstracting this complexity. By leveraging core [DevTools](/dev-tools/) compatible with Rootstock such as [Para Wallet](/use-cases/onboarding-ux/para/), [Reown](/developers/quickstart/reown), developers can build applications that feel like standard web apps while retaining the security of Bitcoin.
 
 ## Core Pillars
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,10 @@ const config = {
           description : 'Looking for information we haven’t covered? Fill out the form below to request a new article, and we’ll consider it in future updates.',
         }
       },
+      trbtcFaucet : {
+        title: 'tRBTC Faucet',
+        url : 'https://faucet.rootstock.io/',
+      },
     },
     // newsHighlight : [
     //   {

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -385,6 +385,10 @@
    "theme.moreLinks.devCheatsheet": {
     "message": "Developer Cheatsheet"
   },
+  "theme.moreLinks.trbtcFaucet": {
+    "message": "tRBTC Faucet",
+    "description": "tRBTC Faucet link label in sidebar"
+  },
   "theme.moreLinks.requestArticle.form.title": {
     "message": "Request a New Article",
     "description": "Request an Article form title"

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -390,6 +390,10 @@
     "message": "¿Busca información que no hayamos cubierto? Rellene el siguiente formulario para solicitar un nuevo artículo, y lo tendremos en cuenta en futuras actualizaciones.",
     "description": "Request an Article form description"
   },
+  "theme.moreLinks.trbtcFaucet": {
+    "message": "Faucet de tRBTC",
+    "description": "tRBTC Faucet link label in sidebar"
+  },
   "theme.navbar.mobileLanguageDropdown.label": {
     "message": "Idiomas",
     "description": "The label for the mobile language switcher dropdown"

--- a/i18n/ja/code.json
+++ b/i18n/ja/code.json
@@ -390,6 +390,10 @@
     "message": "掲載されていない情報をお探しですか？ 下のフォームにご記入いただければ、新しい記事としてリクエストを受け付け、今後のアップデートで検討させていただきます。",
     "description": "Request an Article form description"
   },
+  "theme.moreLinks.trbtcFaucet": {
+    "message": "tRBTCフォーセット",
+    "description": "tRBTC Faucet link label in sidebar"
+  },
   "theme.navbar.mobileLanguageDropdown.label": {
     "message": "言語",
     "description": "The label for the mobile language switcher dropdown"

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -390,6 +390,10 @@
     "message": "원하는 정보가 없으신가요? 아래 양식을 작성해 요청해 주세요. 새로운 게시물 작성 시 참고하여 반영하도록 하겠습니다.",
     "description": "Request an Article form description"
   },
+  "theme.moreLinks.trbtcFaucet": {
+    "message": "tRBTC 파우셋",
+    "description": "tRBTC Faucet link label in sidebar"
+  },
   "theme.navbar.mobileLanguageDropdown.label": {
     "message": "언어",
     "description": "The label for the mobile language switcher dropdown"

--- a/src/_utils/analytics.js
+++ b/src/_utils/analytics.js
@@ -1,0 +1,12 @@
+export function pushDataLayer(event, extra = {}) {
+  if (typeof window === 'undefined') return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event,
+    pageUrl: window.location.href,
+    pagePath: window.location.pathname,
+    pageTitle: document.title,
+    timestamp: new Date().toISOString(),
+    ...extra,
+  });
+}

--- a/src/components/TrackedLink/index.js
+++ b/src/components/TrackedLink/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import Link from '/src/components/Link';
+import { pushDataLayer } from '/src/_utils/analytics';
+
+export default function TrackedLink({ href, event, componentId, componentLabel, children, ...props }) {
+  return (
+    <Link
+      href={href}
+      onClick={() => pushDataLayer(event || 'linkClick', {
+        componentId,
+        componentLabel: componentLabel || (typeof children === 'string' ? children : ''),
+      })}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/theme/DocItem/MoreActions/index.js
+++ b/src/theme/DocItem/MoreActions/index.js
@@ -11,9 +11,11 @@ import EditThisPage from '@theme/EditThisPage';
 import IconPaste from "@theme/Icon/Paste";
 import IconCommunity from "@theme/Icon/Community";
 import IconChangelog from "@theme/Icon/Changelog";
+import IconFaucet from "../../Icon/Faucet";
 
 import Link from '@docusaurus/Link';
 import { RequestArticle } from '../../../components/RequestArticle'
+import { pushDataLayer } from '../../../_utils/analytics'
 
 export default function MoreActions({editUrl}) {
 
@@ -88,6 +90,25 @@ export default function MoreActions({editUrl}) {
               id="theme.moreLinks.devCheatsheet"
             >
               {links.devCheatsheet.title}
+            </Translate>
+          </Link>
+        </li>
+      )}
+      {links.trbtcFaucet && (
+        <li className={`py-3`}>
+          <Link
+            to={links.trbtcFaucet.url}
+            className={`link-base d-inline-flex gap-8 align-items-center`}
+            onClick={() => pushDataLayer('trbtcFaucetClick', {
+              componentId: 'trbtc-faucet-link',
+              componentLabel: links.trbtcFaucet.title,
+            })}
+          >
+            <IconFaucet/>
+            <Translate
+              id="theme.moreLinks.trbtcFaucet"
+            >
+              {links.trbtcFaucet.title}
             </Translate>
           </Link>
         </li>

--- a/src/theme/Icon/Faucet/index.js
+++ b/src/theme/Icon/Faucet/index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export default function IconFaucet({className, ...restProps}) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16"
+         fill="currentColor"
+         className={clsx(className)}
+         aria-hidden="true"
+         {...restProps}>
+      <path d="M8 1.5C6.8 3.2 4 6.2 4 9a4 4 0 0 0 8 0c0-2.8-2.8-5.8-4-7.5Z"/>
+      <path d="M8 11.5a.5.5 0 0 1-.5-.5V9a.5.5 0 0 1 1 0v2a.5.5 0 0 1-.5.5Z" opacity=".6"/>
+    </svg>
+  )
+}

--- a/src/theme/Navbar/AskCookbook/index.js
+++ b/src/theme/Navbar/AskCookbook/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, Suspense } from "react";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { pushDataLayer } from "../../../_utils/analytics";
 
 const BaseAskCookbook = React.lazy(() =>
   import("@cookbookdev/docsbot/react-fixed")
@@ -23,15 +24,9 @@ export default function AskCookbook() {
           // Prevent duplicate listeners
           if (!btn.dataset.listenerAttached) {
             btn.addEventListener("click", () => {
-              window.dataLayer = window.dataLayer || [];
-              window.dataLayer.push({
-                event: "askCookbookClick",
+              pushDataLayer("askCookbookClick", {
                 componentId: "ask-cookbook-button",
                 componentLabel: btn.innerText.trim() || "Ask Cookbook",
-                pageUrl: window.location.href,
-                pagePath: window.location.pathname,
-                pageTitle: document.title,
-                timestamp: new Date().toISOString(),
               });
               console.log("✅ askCookbookClick event fired.");
             });


### PR DESCRIPTION
## Summary

- Adds a **tRBTC Faucet** entry to the "More" sidebar menu (`MoreActions`) with a custom water-drop icon, i18n translations (EN/ES/JA/KO), and GA4 click tracking (`trbtcFaucetClick`).
- Adds GA4 click tracking to the existing **Rootstock Faucet** link in `/dev-tools/additional-tools/` via a new `TrackedLink` component (`faucetClick` / `additional-tools-faucet-link`), converting that page from `.md` to `.mdx`.
- Extracts a shared `pushDataLayer` utility (`src/_utils/analytics.js`) and refactors the existing `AskCookbook` tracking to use it, eliminating duplicated boilerplate.


<img width="212" height="288" alt="Screenshot 2026-05-26 at 5 16 07 PM" src="https://github.com/user-attachments/assets/865d75a7-0ebd-4576-be78-ed8ad11e5e0a" />


## New files

| File | Purpose |
|---|---|
| `src/_utils/analytics.js` | Shared `pushDataLayer(event, extra)` utility with SSR guard |
| `src/components/TrackedLink/index.js` | MDX-compatible link wrapper that fires `pushDataLayer` on click |
| `src/theme/Icon/Faucet/index.js` | 16×16 water-drop SVG icon for the sidebar entry |

## DataLayer events

| Event | `componentId` | Trigger |
|---|---|---|
| `trbtcFaucetClick` | `trbtc-faucet-link` | Sidebar "More" → tRBTC Faucet |
| `faucetClick` | `additional-tools-faucet-link` | General Tools page → Rootstock Faucet |

## Test plan

- [X] Sidebar "More" section shows tRBTC Faucet link with faucet icon
- [X] Clicking it pushes `trbtcFaucetClick` to `window.dataLayer`
- [X] `/dev-tools/additional-tools/` renders correctly (MDX conversion)
- [ ] Clicking Rootstock Faucet on that page pushes `faucetClick` to `window.dataLayer`
- [ ] Both events include `pageUrl`, `pagePath`, `pageTitle`, `timestamp`
- [X] i18n: sidebar label renders correctly in ES, JA, KO
- [ ] `AskCookbook` tracking still works (refactored to use shared utility)
