### PR TITLE
fix: ensure tRBTC faucet GA event fires on external link click

### DIFF
--- a/docs/02-developers/06-integrate/02-flyover/LP/get-started.md
+++ b/docs/02-developers/06-integrate/02-flyover/LP/get-started.md
@@ -177,7 +177,7 @@ The LPS provides several utility scripts that can be helpful for liquidity provi
 - **resign_utils**: Resigns a liquidity provider and withdraws collateral from the contract.
 - **withdraw**: Withdraws liquidity locked in the contract (full balance or specific amount).
 
-For migration-specific examples, see [docs/LP-Migration-Utils.md](./docs/LP-Migration-Utils.md).
+For migration-specific examples, see [LP-Migration-Utils.md](https://github.com/rsksmart/liquidity-provider-server/blob/master/docs/LP-Migration-Utils.md).
 
 ## Monitoring Service
 

--- a/docs/02-developers/06-integrate/02-flyover/LP/security.md
+++ b/docs/02-developers/06-integrate/02-flyover/LP/security.md
@@ -12,7 +12,7 @@ We are committed to conduct our security process in a professional and civil man
 
 ## Responsible Disclosure
 
-For all security related issues, RootstockLabs has two main points of contact. Reach us at <security@rootstocklabs.com> or refer to our [Bug Bounty Program](https://www.rootstocklabs.com/bug-bounty-program/). **Do not open up a GitHub issue if the bug is a security vulnerability**
+For all security related issues, RootstockLabs has two main points of contact. Reach us at [security@rootstocklabs.com](mailto:security@rootstocklabs.com) or refer to our [Bug Bounty Program](https://www.rootstocklabs.com/bug-bounty-program/). **Do not open up a GitHub issue if the bug is a security vulnerability**
 
 **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/rsksmart/liquidity-provider-server/issues).
 

--- a/src/theme/DocItem/MoreActions/index.js
+++ b/src/theme/DocItem/MoreActions/index.js
@@ -15,7 +15,7 @@ import IconFaucet from "../../Icon/Faucet";
 
 import Link from '@docusaurus/Link';
 import { RequestArticle } from '../../../components/RequestArticle'
-import { pushDataLayer } from '../../../_utils/analytics'
+import TrackedLink from '../../../components/TrackedLink'
 
 export default function MoreActions({editUrl}) {
 
@@ -96,13 +96,12 @@ export default function MoreActions({editUrl}) {
       )}
       {links.trbtcFaucet && (
         <li className={`py-3`}>
-          <Link
-            to={links.trbtcFaucet.url}
+          <TrackedLink
+            href={links.trbtcFaucet.url}
+            event="trbtcFaucetClick"
+            componentId="trbtc-faucet-link"
+            componentLabel={links.trbtcFaucet.title}
             className={`link-base d-inline-flex gap-8 align-items-center`}
-            onClick={() => pushDataLayer('trbtcFaucetClick', {
-              componentId: 'trbtc-faucet-link',
-              componentLabel: links.trbtcFaucet.title,
-            })}
           >
             <IconFaucet/>
             <Translate
@@ -110,7 +109,7 @@ export default function MoreActions({editUrl}) {
             >
               {links.trbtcFaucet.title}
             </Translate>
-          </Link>
+          </TrackedLink>
         </li>
       )}
     </ul>


### PR DESCRIPTION
## Problem

The tRBTC faucet link in the More menu was using Docusaurus `<Link to={...}>`  for an external URL. This renders as a standard `<a>` tag without `target="_blank"`,  so the browser navigates away in the same tab before GTM has time to asynchronously  process the `trbtcFaucetClick` dataLayer push and send the hit to GA. As a result,  the event was consistently lost.

## Fix

Replaced the inline `<Link>` + `pushDataLayer` call with the existing `TrackedLink`  component, using `href` instead of `to`.

`TrackedLink` delegates to the project's custom `Link` wrapper, which automatically  sets `target="_blank"` for external URLs — the faucet opens in a new tab, the current  tab stays alive, and GTM has time to process the event.

This also removes duplicated inline tracking logic and makes the implementation  consistent with how `TrackedLink` was designed to be used.

## Changes

- `MoreActions/index.js`: replaced `<Link to>` + inline `onClick` with `<TrackedLink href>`
- Removed direct `pushDataLayer` import from this file (handled inside `TrackedLink`)
