### PR TITLE
feat(navbar): add MetaMask wallet connect button

### DIFF
--- a/src/components/WalletConnectButton/index.js
+++ b/src/components/WalletConnectButton/index.js
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import clsx from 'clsx'
+import BrowserOnly from '@docusaurus/BrowserOnly'
+import IconRbtc from '@theme/Icon/Rbtc'
+
+// Rootstock chain ids (as reported by MetaMask, lowercase hex) mapped to the
+// native currency label shown next to the balance.
+const CURRENCY_BY_CHAIN_ID = {
+  '0x1e': 'RBTC', // Rootstock Mainnet
+  '0x1f': 'tRBTC', // Rootstock Testnet
+}
+const DEFAULT_CURRENCY_SYMBOL = 'RBTC'
+
+// EIP-1193 error code for "user rejected request" (e.g. closed the MetaMask
+// popup) - not a real failure, so we don't log it.
+const USER_REJECTED_ERROR_CODE = 4001
+
+function shortenAddress(address) {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}
+
+// Formats an `eth_getBalance` wei hex string into a trimmed decimal string
+// (max 4 fraction digits). Plain BigInt math avoids pulling in a
+// bignumber/ethers dependency just for this.
+function formatBalance(weiHex) {
+  const wei = BigInt(weiHex)
+  const divisor = 10n ** 18n
+  const whole = wei / divisor
+  const fraction = wei % divisor
+  const fractionStr = fraction.toString().padStart(18, '0').slice(0, 4)
+  return `${whole.toString()}.${fractionStr}`.replace(/\.?0+$/, '') || '0'
+}
+
+function WalletConnectButton() {
+  const [address, setAddress] = useState(null)
+  const [chainId, setChainId] = useState(null)
+  const [balance, setBalance] = useState(null)
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const containerRef = useRef(null)
+
+  const fetchBalance = useCallback(async (account) => {
+    if (!account) return
+    try {
+      const weiHex = await window.ethereum.request({
+        method: 'eth_getBalance',
+        params: [account, 'latest'],
+      })
+      setBalance(formatBalance(weiHex))
+    } catch (error) {
+      console.error('Failed to fetch RBTC balance:', error)
+    }
+  }, [])
+
+  // Syncs component state to a given account (or clears it when disconnected).
+  const refreshAccount = useCallback(
+    async (account) => {
+      if (!account) {
+        setAddress(null)
+        setChainId(null)
+        setBalance(null)
+        return
+      }
+      setAddress(account)
+      try {
+        const currentChainId = await window.ethereum.request({ method: 'eth_chainId' })
+        setChainId(currentChainId)
+      } catch (error) {
+        console.error('Failed to read the connected chain id:', error)
+      }
+      await fetchBalance(account)
+    },
+    [fetchBalance],
+  )
+
+  useEffect(() => {
+    if (typeof window.ethereum === 'undefined') {
+      return undefined
+    }
+
+    // Restores an already-authorized connection without prompting the user.
+    window.ethereum
+      .request({ method: 'eth_accounts' })
+      .then((accounts) => refreshAccount(accounts[0]))
+      .catch((error) => console.error('Failed to read connected accounts:', error))
+
+    const handleAccountsChanged = (accounts) => refreshAccount(accounts[0])
+    const handleChainChanged = () => {
+      window.ethereum
+        .request({ method: 'eth_accounts' })
+        .then((accounts) => refreshAccount(accounts[0]))
+        .catch((error) => console.error('Failed to refresh account after network change:', error))
+    }
+
+    window.ethereum.on('accountsChanged', handleAccountsChanged)
+    window.ethereum.on('chainChanged', handleChainChanged)
+
+    return () => {
+      window.ethereum.removeListener?.('accountsChanged', handleAccountsChanged)
+      window.ethereum.removeListener?.('chainChanged', handleChainChanged)
+    }
+  }, [refreshAccount])
+
+  useEffect(() => {
+    function handleOutsideClick(event) {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setMenuOpen(false)
+      }
+    }
+    function handleEscape(event) {
+      if (event.key === 'Escape') setMenuOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutsideClick)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [])
+
+  async function connectWallet() {
+    if (typeof window.ethereum === 'undefined') {
+      alert('MetaMask is not installed. Please install MetaMask to use this feature.')
+      return
+    }
+    setIsConnecting(true)
+    try {
+      const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
+      await refreshAccount(accounts[0])
+    } catch (error) {
+      if (error?.code !== USER_REJECTED_ERROR_CODE) {
+        console.error('Failed to connect wallet:', error)
+      }
+    } finally {
+      setIsConnecting(false)
+    }
+  }
+
+  async function disconnectWallet() {
+    setMenuOpen(false)
+    try {
+      // Best-effort: supported by newer MetaMask versions (EIP-2255). Older
+      // wallets have no API for a dApp to force a disconnect, so this is
+      // wrapped in a try/catch and we always clear local state below.
+      await window.ethereum?.request({
+        method: 'wallet_revokePermissions',
+        params: [{ eth_accounts: {} }],
+      })
+    } catch (error) {
+      // Not supported everywhere - ignore and fall back to local state only.
+    }
+    setAddress(null)
+    setChainId(null)
+    setBalance(null)
+  }
+
+  if (!address) {
+    return (
+      <button
+        type="button"
+        className="btn btn-outline btn-sm wallet-connect-trigger"
+        onClick={connectWallet}
+        disabled={isConnecting}
+      >
+        {isConnecting ? 'Connecting...' : 'Connect Wallet'}
+      </button>
+    )
+  }
+
+  const currencySymbol = CURRENCY_BY_CHAIN_ID[chainId?.toLowerCase()] || DEFAULT_CURRENCY_SYMBOL
+
+  return (
+    <div className="wallet-connect" ref={containerRef}>
+      <div className={clsx('dropdown', menuOpen && 'dropdown--show')}>
+        <button
+          type="button"
+          className="wallet-connect-trigger"
+          onClick={() => setMenuOpen((open) => !open)}
+          aria-haspopup="true"
+          aria-expanded={menuOpen}
+          aria-label={`Wallet connected: ${address}. Toggle wallet menu.`}
+        >
+          {shortenAddress(address)}
+        </button>
+        <ul className="dropdown__menu wallet-connect-menu" role="menu">
+          <li
+            className="wallet-connect-balance"
+            role="none"
+            aria-label={`Balance: ${balance !== null ? `${balance} ${currencySymbol}` : 'loading'}`}
+          >
+            <IconRbtc />
+            <span>{balance !== null ? `${balance} ${currencySymbol}` : 'Loading balance...'}</span>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className="dropdown__link wallet-connect-disconnect"
+              onClick={disconnectWallet}
+            >
+              Disconnect
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+// `window.ethereum` only exists in the browser, so this is rendered lazily
+// via BrowserOnly to keep the static/SSR build clean (same pattern used by
+// AddNetworkButtons).
+export default function WrappedWalletConnectButton() {
+  return (
+    <BrowserOnly fallback={<span className="wallet-connect-placeholder" aria-hidden="true" />}>
+      {() => <WalletConnectButton />}
+    </BrowserOnly>
+  )
+}

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -35,7 +35,8 @@
 'components/codeblock',
 'components/accessibe-widget',
 'components/sliders',
-'components/markdown-actions';
+'components/markdown-actions',
+'components/wallet-connect';
 
 @import 'pages/front';
 /*! purgecss end ignore */

--- a/src/scss/components/_wallet-connect.scss
+++ b/src/scss/components/_wallet-connect.scss
@@ -1,0 +1,86 @@
+// Wallet connect button (navbar) - mirrors the remix-menu / markdown-actions
+// dropdown look so navbar-adjacent dropdowns stay visually consistent.
+.wallet-connect {
+  position: relative;
+}
+
+.wallet-connect .dropdown {
+  position: relative;
+}
+
+.wallet-connect-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+  cursor: pointer;
+  border-radius: 999px;
+  border: 1px solid var(--bs-body-color);
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  white-space: nowrap;
+  transition: background-color 0.15s ease;
+}
+
+.wallet-connect-trigger:hover,
+.wallet-connect-trigger:focus {
+  background: var(--ifm-hover-overlay);
+  color: var(--bs-body-color);
+}
+
+.wallet-connect-trigger:focus-visible {
+  outline: 2px solid var(--ifm-color-primary, #3578e5);
+  outline-offset: 2px;
+}
+
+.wallet-connect-trigger:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.wallet-connect .dropdown__menu {
+  z-index: 1000;
+  min-width: 200px;
+  right: 0;
+  left: auto;
+  padding: 0.5rem 0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.wallet-connect-balance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  font-size: 0.875rem;
+  color: var(--bs-body-color);
+}
+
+.wallet-connect-disconnect {
+  display: flex;
+  width: 100%;
+  padding: 8px 14px;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: var(--bs-body-color);
+  font: inherit;
+  cursor: pointer;
+}
+
+.wallet-connect-disconnect:hover {
+  background-color: var(--ifm-hover-overlay);
+}
+
+@media (max-width: 768px) {
+  .wallet-connect .dropdown__menu {
+    left: auto;
+    right: 0;
+    min-width: min(220px, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -15,6 +15,7 @@ import Link from '@docusaurus/Link';
 
 import AIButton from "@theme/Navbar/AIButton";
 import LocaleDropdown from "@theme/Navbar/LocaleDropdown";
+import WalletConnectButton from "/src/components/WalletConnectButton";
 
 function useNavbarItems() {
   // TODO temporary casting until ThemeConfig type is improved
@@ -88,6 +89,7 @@ export default function NavbarContent() {
           <RightNavbarItems items={rightItems} />
           <LocaleDropdown />
           <NavbarColorModeToggle />
+          <WalletConnectButton />
         </div>
       }
     />


### PR DESCRIPTION
## What
Adds a `WalletConnectButton` component (`src/components/WalletConnectButton`) that connects to MetaMask via `window.ethereum`. In the disconnected state it renders a "Connect Wallet" button; once connected it shows the truncated wallet address, and clicking it opens a dropdown with the RBTC/tRBTC balance and a Disconnect action. Wired into the desktop navbar's right-hand corner (`src/theme/Navbar/Content`), alongside the locale and color-mode controls.

## Why
Lets devportal visitors connect their MetaMask wallet directly from the navbar to view their address and Rootstock balance, without adding a new wallet SDK dependency (uses plain EIP-1193 `window.ethereum` calls + `BigInt` math for balance formatting, consistent with the existing `AddNetworkButtons` component).

## Details
- Restores an already-authorized session silently on load (`eth_accounts`), and reacts to `accountsChanged` / `chainChanged`.
- Balance is fetched via `eth_getBalance` and labeled `RBTC` (mainnet, chain `0x1e`) or `tRBTC` (testnet, chain `0x1f`), defaulting to `RBTC` on other networks.
- Disconnect clears local state and best-effort calls `wallet_revokePermissions` (EIP-2255) where supported; older MetaMask versions have no way to force-revoke a dApp connection, so this is a graceful no-op fallback.
- Rendered via `BrowserOnly` (SSR-safe, matches `AddNetworkButtons`), keyboard/click-outside dismissible dropdown, `aria-*` attributes for accessibility, and a `_wallet-connect.scss` partial that reuses existing dropdown tokens/patterns (mirrors `remix-menu` / `markdown-actions`) for light/dark theme consistency.

## Test plan
- [ ] `yarn build` passes (verified locally)
- [ ] Manually verify in a browser with MetaMask: connect, view address + RBTC balance, disconnect
- [ ] Verify dropdown closes on outside click / Escape, and is keyboard accessible
- [ ] Verify appearance in both light and dark theme, and on mobile/desktop breakpoints

## Note
`yarn.lock` had pre-existing local drift (unrelated dependency version churn) that was **not** included in this PR.