### PR TITLE
feat: enable DocSearch Insights and click analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -339,14 +339,22 @@ const config = {
         // The application ID provided by Algolia
         appId: 'WAFPQL14PU',
 
-        // Public API key: it is safe to commit it
-        apiKey: '78aa26683ec349ff7e4a7c2d723e4cb7',
+        // Search-only API key (public). Safe to commit.
+        apiKey: '9e905931e536c00dbe951ca1fb06ae06',
 
         indexName: 'dev-rootstock',
 
         // Optional: see doc section below
         contextualSearch: true,
-      }
+
+        // Enables Algolia Insights + clickAnalytics on search requests
+        insights: true,
+
+        // Reinforce click tracking for Analytics CTR metrics
+        searchParameters: {
+          clickAnalytics: true,
+        },
+      },
     }),
 };
 


### PR DESCRIPTION
## Summary
- Enable Algolia DocSearch `insights: true` and `clickAnalytics` so search result clicks are sent to Algolia Analytics (needed for CTR / search-success metrics on the Devportal Health dashboard).
- Switch the frontend `apiKey` to the public **search-only** key.

## Why
Overview already shows ~1.3K search requests, but Analytics CTR stayed at 0 because DocSearch was not emitting click events. With Insights on, Analytics (DE region) can populate `trackedSearchCount` / `clickCount` after deploy traffic accumulates.

## Test plan
- [ ] Search on a preview/staging build and click a result
- [ ] Confirm events appear in Algolia → Events / Analytics for index `dev-rootstock` (region DE)
- [ ] Confirm site search still works (contextualSearch unchanged)
- [ ] After a few days of traffic, Devportal Health `docs-health:refresh-algolia` can prefer CTR over the no-result proxy


Made with [Cursor](https://cursor.com)