### PR TITLE
DX-1955 | docs: add libraries info in the Troubleshooting section and Foundry guide

### DIFF
--- a/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
+++ b/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
@@ -302,6 +302,12 @@ Replace:
 
 > The `> <contract-name>.json` at the end of the command redirects the Standard JSON input output into a file in the current directory, which can then be uploaded as-is to the Rootstock Explorer verification tool.
 
+If your contract links external libraries, add one `--libraries` flag per library so they are written into `settings.libraries` of the generated JSON:
+
+```bash
+--libraries <library-file>:<library-name>:<library-address>
+```
+
 ### 4. Hardhat Verification
 
 Select Hardhat as your verification method to verify contracts directly from your Hardhat project. This method does not require uploading files through the interface. Instead, verification is performed using the Hardhat CLI.
@@ -363,6 +369,12 @@ Replace:
 - `<contract-name>` → name of the contract inside that file.
 - `<compiler-version>` → the Solidity compiler version used to compile and deploy the contract (for example, `v0.8.28`).
 
+If your contract links external libraries, add one `--libraries` flag per library. Verification does not reuse the linking from your deploy, so each library has to be named again:
+
+```bash
+--libraries <library-file>:<library-name>:<library-address>
+```
+
 Once the command finishes, your contract will appear as Verified on the Rootstock Explorer.
 
 For a detailed walkthrough, see [Verify Smart Contracts using Foundry](/developers/smart-contracts/foundry/verify-smart-contracts/).
@@ -391,33 +403,54 @@ Once you have entered all the details, click "Verify Contract".
 
 ## Troubleshooting
 
-- Here are some common errors and their solutions:
+Verification compares the bytecode the explorer recompiles against the bytecode on chain. The code body has to match; a metadata footer that differs is tolerated when it is the same length and still decodes as valid metadata. Every failure below is a real difference between the compilation you submitted and the one that produced the deployed bytecode — except where the failure happens in your local tooling, before anything reaches the explorer.
 
 <Accordion>
   <Accordion.Item eventKey="0">
     <Accordion.Header as="h3">Compiler version mismatch</Accordion.Header>
     <Accordion.Body>
-      - Confirm the exact **Solc version** used to compile your contract.<br/>
-      - Retrieve the version from your compilation artifacts.
+      - Use the exact **Solc version** your deploy used, not the version shown in an example command. Do not read it off the `pragma` either: a pragma often only bounds the version, and even when it pins one exactly it omits the `+commit` hash that identifies the build.
+      - Foundry: read `solc_version` from `foundry.toml` (`solc` is the same setting; Foundry accepts either), or take the full version from `metadata.compiler.version` in `out/<File>.sol/<Contract>.json`.
+      - Hardhat: take `solcLongVersion` from the build info under `artifacts/build-info/` — it carries the `+commit.…` suffix that `solcVersion` omits. In your config it lives under `solidity` in Hardhat 2 (a bare version string, `solidity.version`, or an entry in `solidity.compilers[]`), and under the compiler profile in Hardhat 3.
     </Accordion.Body>
   </Accordion.Item>
   <Accordion.Item eventKey="1">
-    <Accordion.Header as="h3">Invalid constructor arguments</Accordion.Header>
+    <Accordion.Header as="h3">Library not found / address mismatch</Accordion.Header>
     <Accordion.Body>
-      - Verify the precise **encoding**, **order**, and **types** of your constructor arguments.
+      `forge verify-contract` submits **only** the libraries in your Foundry configuration for that command — the `--libraries` flags you pass, plus any `libraries` entry in `foundry.toml`. It never reads your deploy's broadcast file or artifacts, so the flags your deploy script passed have to be repeated here. A missing library leaves unresolved placeholders in the recompiled bytecode, so the comparison fails.
+
+      - Pass every deployed library, one `--libraries` flag each:
+
+      ```bash
+      --libraries src/libraries/MyLib.sol:MyLib:0x1111111111111111111111111111111111111111
+      ```
+
+      - The file part is the source path as the compiler sees it, after remappings. For a library that comes from a dependency, that is its path inside the dependency — for example `node_modules/@scope/pkg/contracts/MyLib.sol:MyLib:0x…`.
+      - The source of truth for names and addresses is the top-level `libraries[]` array in `broadcast/<script>.s.sol/<chainId>/run-latest.json`.
+      - To see what your command actually ships before submitting, dump the Standard JSON input and inspect its `settings.libraries`:
+
+      ```bash
+      forge verify-contract ... --show-standard-json-input > standard-input.json
+      ```
     </Accordion.Body>
   </Accordion.Item>
   <Accordion.Item eventKey="2">
-    <Accordion.Header as="h3">Library not found / address mismatch</Accordion.Header>
+    <Accordion.Header as="h3">Invalid constructor arguments</Accordion.Header>
     <Accordion.Body>
-      - Ensure **library names** match bytecode placeholders.<br/>
-      - Add the correct **deployed addresses** for each library.
+      - Verify the precise **encoding**, **order**, and **types** of your constructor arguments.
+      - Read the values from the `arguments` field of the deploying entry in `transactions[]` of `broadcast/<script>.s.sol/<chainId>/run-latest.json` (`null` when the constructor takes none). They are stored decoded, so ABI-encode them with [cast abi-encode](https://getfoundry.sh/cast/reference/abi-encode/) before passing them.
+      - `--guess-constructor-args` can fail its own preflight with `Local bytecode doesn't match on-chain bytecode` even when your local artifact and the deployed bytecode are identical. Drop `--guess-constructor-args` and `--rpc-url`, and pass the arguments explicitly instead:
+
+      ```bash
+      --constructor-args 0x00000000000000000000000000000000000000000000000000000000000003e8
+      ```
     </Accordion.Body>
   </Accordion.Item>
   <Accordion.Item eventKey="3">
-    <Accordion.Header as="h3">Optimization runs differ</Accordion.Header>
+    <Accordion.Header as="h3">Optimization settings differ</Accordion.Header>
     <Accordion.Body>
-      - Align the number of **optimization runs** with your compilation settings.
+      - The optimizer flag, the number of **runs**, and the **EVM version** all change the output bytecode. Each must match what you compiled with.
+      - Read them from `foundry.toml` (`optimizer`, `optimizer_runs`, `evm_version`) or from your Hardhat config. Do not assume the form defaults match your project.
     </Accordion.Body>
   </Accordion.Item>
   <Accordion.Item eventKey="4">
@@ -429,14 +462,14 @@ Once you have entered all the details, click "Verify Contract".
   <Accordion.Item eventKey="5">
     <Accordion.Header as="h3">Proxy and Implementation</Accordion.Header>
     <Accordion.Body>
-      - Verify the **implementation contract**.<br/>
-      - Note any **proxy-aware UI** (if available) and how to link it.
+      - Verify the **implementation contract** and the proxy separately. Each is its own address with its own source and constructor arguments.
+      - A proxy's constructor arguments usually include the implementation address and the encoded initializer call. Read them from the deploy broadcast file rather than reconstructing them by hand.
     </Accordion.Body>
   </Accordion.Item>
 </Accordion>
 
 :::tip[Tip]
-If verification keeps failing, try matching the compiler settings directly from your Hardhat or Foundry build artifacts.
+If verification keeps failing, stop adjusting the form and compare inputs instead. Take the Standard JSON your tooling actually submits (`forge verify-contract ... --show-standard-json-input`) and check it against the build info from the deploy. The difference between those two files is the reason verification fails.
 :::
 
 ## Resources

--- a/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
+++ b/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
@@ -6,7 +6,7 @@ description: "Learn how to verify your Rootstock smart contract using forge."
 tags: [guides, developers, smart contracts, rsk, rootstock, foundry, dApps, verify]
 ---
 
-In this section, you'll verify your `counter` smart contract to the Rootstock Explorer using Foundry, so the users of you dApp can be able to see the actual code of your contract to analyze that it doesn't have malicious code, and they can also interact with it.
+In this section, you'll verify your `counter` smart contract on the Rootstock Explorer using Foundry, so the users of your dApp can see the actual code of your contract, confirm it doesn't have malicious code, and interact with it.
 
 ## Verify simple contract
 
@@ -63,11 +63,11 @@ result:
 0x00000000000000000000000000000000000000000000000000000000000003e8
 ```
 
-And, then, you can run the verification command passing the constructor argment as ABI encoded:
+Then you can run the verification command passing the constructor argument as ABI encoded:
 
 ```bash
 forge verify-contract \
-    --constructor-args 0x00000000000000000000000000000000000000000000000000000000000003e8
+    --constructor-args 0x00000000000000000000000000000000000000000000000000000000000003e8 \
     --chain-id 31 \
     --watch \
     --compiler-version v0.8.30 \
@@ -75,4 +75,37 @@ forge verify-contract \
     --verifier-url https://be.explorer.testnet.rootstock.io/api/v3/etherscan \
     0x499e802a6825d30482582d9b9dd669ba82ba8ba4 \
     src/Counter.sol:Counter
+```
+
+:::tip[Tip]
+If you deployed with a script, you do not have to reconstruct the arguments from memory. Each entry in `transactions[]` of `broadcast/<script>.s.sol/<chainId>/run-latest.json` carries its own `arguments`, holding what was passed at deploy time — pick the transaction that created your contract. They are stored decoded, so run them through `cast abi-encode` before passing them to `--constructor-args`.
+:::
+
+## Verify a contract that uses libraries
+
+`forge verify-contract` submits only the libraries in your Foundry configuration for that command — the `--libraries` flags you pass, plus any `libraries` entry in `foundry.toml`. It **never** reads your deploy's broadcast file or artifacts, even when your deploy script passed those same flags, so a contract that deployed fine will fail verification if a library is left out. The recompiled bytecode keeps unresolved placeholders where the missing library should be, and the comparison against the deployed bytecode fails.
+
+Pass every deployed library, one flag each:
+
+```bash
+forge verify-contract \
+    --chain-id 31 \
+    --watch \
+    --compiler-version v0.8.30 \
+    --verifier custom \
+    --verifier-url https://be.explorer.testnet.rootstock.io/api/v3/etherscan \
+    --libraries src/libraries/MathLib.sol:MathLib:0x1111111111111111111111111111111111111111 \
+    --libraries src/libraries/QuoteLib.sol:QuoteLib:0x2222222222222222222222222222222222222222 \
+    <contract-address> \
+    src/Vault.sol:Vault
+```
+
+The file part of each flag is the source path as the compiler sees it, after remappings. A library that comes from a dependency keeps the path inside that dependency, for example `node_modules/@scope/pkg/contracts/MathLib.sol:MathLib:0x…`.
+
+The source of truth for library names and addresses is the top-level `libraries[]` array in `broadcast/<script>.s.sol/<chainId>/run-latest.json`. If you no longer have the broadcast file, the same linking is recorded as `metadata.settings.libraries` in the build artifact.
+
+To see exactly which libraries your command ships before you submit it, dump the Standard JSON input and inspect `settings.libraries`:
+
+```bash
+forge verify-contract ... --show-standard-json-input > standard-input.json
 ```


### PR DESCRIPTION
Related to **DX-1813** (Unverifiable contracts using foundry — Liquidity Bridge Contract).

## Why

Contracts that deployed fine failed to verify, and the troubleshooting section could not have helped: its entries were generic ("align the number of optimization runs") and none named the two causes we actually found.

The one that cost the most time: **`forge verify-contract` never reuses the linking from your deploy** — not even when the deploy script passed those same `--libraries` flags. A missing library leaves unresolved placeholders in the recompiled bytecode, so verification fails with no hint as to why.

## What changed

**Troubleshooting** (`rootstock-explorer.md`) — rewritten around the real failures:

- **Library not found** — the rule above, plus where the values live (`run-latest.json` → top-level `libraries[]`), `--show-standard-json-input` to see what your command actually ships, and the detail that bit us: the file part of each flag is the source path *after remappings*, so a library from a dependency keeps its path inside that dependency.
- **Invalid constructor arguments** — `--guess-constructor-args` can fail its own preflight with `Local bytecode doesn't match on-chain bytecode` even when the local artifact and the deployed bytecode are byte-identical; drop it and pass `--constructor-args`. The broadcast file stores `arguments` decoded, so they need `cast abi-encode` first.
- **Compiler version mismatch** — where the version lives per toolchain, and why the `pragma` does not settle it (it often only bounds the version, and never carries the `+commit` hash).
- **Optimization settings** and **Proxy and Implementation** — sharpened.
- A lead-in stating what verification actually compares.

**Foundry guide** (`05-foundry/verify-smart-contracts.md`) — new "Verify a contract that uses libraries" section with a worked command, and a fix for a latent bug: the `--constructor-args` example was missing its trailing `\`, so the copied command broke.

## Verification

`yarn build` clean across all four locales; `yarn check-links` reports 0 broken links and 0 broken anchors. Every claim was checked against the DX-1813 evidence and, where it concerns tool behaviour, re-measured against the reproduction repo — including the preserved `--show-standard-json-input` dumps from the incident.

## Stacked PR

DX-1954 (via-IR considerations) builds on this branch, since it edits the same two pages. **Merge this one first.**
