### PR TITLE
DX-1954 | docs: article on considerations when using via-IR

### DIFF
--- a/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
+++ b/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
@@ -432,7 +432,7 @@ Verification compares the bytecode the explorer recompiles against the bytecode 
       ```
 
       - The `grep` picks the build-info file holding your target, since a project can accumulate several. The `jq` filter names three keys because Standard JSON accepts only `language`, `sources`, and `settings`; Foundry also stores `allowPaths`, `basePath`, `includePaths`, and `version` under `.input` for its own use.
-      - That trim is part of the recipe, not a fallback. This explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it answers `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,332 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,091 bytes.
+      - That trim is part of the recipe, not a fallback. This explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it answers `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,661 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,404 bytes.
       - Check the trim before submitting, because under via-IR removing sources can change the output. Recompile it with the same Solc version the deploy used (`solcVersion` in the build-info file) and compare the target's creation bytecode against the build info — the two digests must be equal, and if they differ, put the sources back:
 
       ```bash

--- a/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
+++ b/docs/02-developers/05-smart-contracts/04-verify-smart-contracts/rootstock-explorer.md
@@ -302,6 +302,10 @@ Replace:
 
 > The `> <contract-name>.json` at the end of the command redirects the Standard JSON input output into a file in the current directory, which can then be uploaded as-is to the Rootstock Explorer verification tool.
 
+:::warning[via-IR projects]
+`--show-standard-json-input` emits only the target contract and its imports. If your project compiles with `via_ir = true`, that is not the compilation unit that produced your bytecode, so this input is not guaranteed to reproduce it. Submit it, and if it comes back as a bytecode mismatch, rebuild the input from the build info your deploy wrote — see the via-IR entry under [Troubleshooting](#troubleshooting).
+:::
+
 If your contract links external libraries, add one `--libraries` flag per library so they are written into `settings.libraries` of the generated JSON:
 
 ```bash
@@ -415,6 +419,43 @@ Verification compares the bytecode the explorer recompiles against the bytecode 
     </Accordion.Body>
   </Accordion.Item>
   <Accordion.Item eventKey="1">
+    <Accordion.Header as="h3">Bytecode mismatch with via-IR enabled</Accordion.Header>
+    <Accordion.Body>
+      With `via_ir = true`, Solc output for a contract depends on **which other sources were in the compilation unit**, not only on the contract and its imports. `forge verify-contract` submits just the target's import closure, a smaller set than the one your deploy compiled, so the recompiled bytecode can differ. Run the plain command first: on the project this guidance comes from, thirteen of the fourteen deployed contracts verified with it, and the one that failed was the largest. Once it fails for a given source tree it keeps failing, deterministically, until the input changes.
+
+      **For a contract that is already deployed**, the compilation unit it was deployed from is the one input guaranteed to reproduce its bytecode. Recover it from the build info of the deploy — the archived artifact if you kept one, otherwise a build of the exact commit you deployed, since a source added or removed since then can change the output — then drop `test/` and `script/` so the submission fits the explorer's budget:
+
+      ```bash
+      forge build --build-info
+      grep -l '"src/Vault.sol"' out/build-info/*.json
+      jq '.input | {language, sources: (.sources | with_entries(select((.key | startswith("test/")) or (.key | startswith("script/")) | not))), settings}' out/build-info/<hash>.json > standard-input.json
+      ```
+
+      - The `grep` picks the build-info file holding your target, since a project can accumulate several. The `jq` filter names three keys because Standard JSON accepts only `language`, `sources`, and `settings`; Foundry also stores `allowPaths`, `basePath`, `includePaths`, and `version` under `.input` for its own use.
+      - That trim is part of the recipe, not a fallback. This explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it answers `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,332 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,091 bytes.
+      - Check the trim before submitting, because under via-IR removing sources can change the output. Recompile it with the same Solc version the deploy used (`solcVersion` in the build-info file) and compare the target's creation bytecode against the build info — the two digests must be equal, and if they differ, put the sources back:
+
+      ```bash
+      jq -r '.output.contracts["src/Vault.sol"].Vault.evm.bytecode.object' out/build-info/<hash>.json | shasum -a 256
+      solc --standard-json standard-input.json > recompiled.json && jq -r '.errors // [] | map(select(.severity=="error")) | length' recompiled.json
+      jq -r '.contracts["src/Vault.sol"].Vault.evm.bytecode.object' recompiled.json | shasum -a 256
+      ```
+
+      - Submit the result through **Standard JSON Input**. Redeploying from a smaller tree is not an option here — the address and its state are already live — so reproducing the original compilation unit is the only path.
+
+      **Before your next deployment**, put the filters on the command that compiles the deploy and keep the build info that run writes:
+
+      ```bash
+      forge script script/Deploy.s.sol --rpc-url <rpc-url> --broadcast --build-info --skip 'test/**'
+      ```
+
+      - Use globs, not the bare `test` / `script` aliases. `--skip` filters which files compile as *targets*, not what ends up in the unit: anything a surviving target imports comes back. The aliases match only `.t.sol` and `.s.sol`, so a helper like `test/BaseTest.sol` survives and drags its imports with it. On this project, of 127 sources the aliases left 96, `'test/**'` left 83, and `'test/**' 'script/**'` — usable on `forge build`, not on the deploy command — left 55.
+      - Never pass `--skip script` to `forge script`: it skips the script being run, and the run stops with `Could not find target contract`.
+      - Keep the `out/build-info/<hash>.json` the deploy wrote, **outside** `out/`, since `forge build --force` clears that folder. Without it you are rebuilding from the deployed commit, where anything added or removed since the deploy can change the via-IR output. If the code body does reproduce, a metadata footer that differs by the same length still verifies here, though some other explorers record that as a partial match.
+      - Turning via-IR off is the other pre-deployment option and it removes the failure mode outright, since legacy codegen is not source-set sensitive. That is a decision about your contracts, not about verification.
+    </Accordion.Body>
+  </Accordion.Item>
+  <Accordion.Item eventKey="2">
     <Accordion.Header as="h3">Library not found / address mismatch</Accordion.Header>
     <Accordion.Body>
       `forge verify-contract` submits **only** the libraries in your Foundry configuration for that command — the `--libraries` flags you pass, plus any `libraries` entry in `foundry.toml`. It never reads your deploy's broadcast file or artifacts, so the flags your deploy script passed have to be repeated here. A missing library leaves unresolved placeholders in the recompiled bytecode, so the comparison fails.
@@ -434,7 +475,7 @@ Verification compares the bytecode the explorer recompiles against the bytecode 
       ```
     </Accordion.Body>
   </Accordion.Item>
-  <Accordion.Item eventKey="2">
+  <Accordion.Item eventKey="3">
     <Accordion.Header as="h3">Invalid constructor arguments</Accordion.Header>
     <Accordion.Body>
       - Verify the precise **encoding**, **order**, and **types** of your constructor arguments.
@@ -446,20 +487,20 @@ Verification compares the bytecode the explorer recompiles against the bytecode 
       ```
     </Accordion.Body>
   </Accordion.Item>
-  <Accordion.Item eventKey="3">
+  <Accordion.Item eventKey="4">
     <Accordion.Header as="h3">Optimization settings differ</Accordion.Header>
     <Accordion.Body>
       - The optimizer flag, the number of **runs**, and the **EVM version** all change the output bytecode. Each must match what you compiled with.
       - Read them from `foundry.toml` (`optimizer`, `optimizer_runs`, `evm_version`) or from your Hardhat config. Do not assume the form defaults match your project.
     </Accordion.Body>
   </Accordion.Item>
-  <Accordion.Item eventKey="4">
+  <Accordion.Item eventKey="5">
     <Accordion.Header as="h3">Flattening / import issues</Accordion.Header>
     <Accordion.Body>
       - Consider using the **Standard JSON** verification method to avoid path or flattening issues.
     </Accordion.Body>
   </Accordion.Item>
-  <Accordion.Item eventKey="5">
+  <Accordion.Item eventKey="6">
     <Accordion.Header as="h3">Proxy and Implementation</Accordion.Header>
     <Accordion.Body>
       - Verify the **implementation contract** and the proxy separately. Each is its own address with its own source and constructor arguments.

--- a/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
+++ b/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
@@ -136,7 +136,7 @@ jq '.input | {language, sources: (.sources | with_entries(select((.key | startsw
 
 Standard JSON accepts only `language`, `sources`, and `settings`, which is why the filter names them; Foundry's build info also keeps `allowPaths`, `basePath`, `includePaths`, and `version` under `.input` for its own use.
 
-The trim is part of the recipe, not a fallback: the Rootstock Explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it returns `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,332 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,091 bytes.
+The trim is part of the recipe, not a fallback: the Rootstock Explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it returns `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,661 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,404 bytes.
 
 Submit `standard-input.json` through the **Standard JSON Input** method on the [Rootstock Explorer](/developers/smart-contracts/verify-smart-contracts/rootstock-explorer/).
 

--- a/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
+++ b/docs/02-developers/05-smart-contracts/05-foundry/verify-smart-contracts.md
@@ -109,3 +109,72 @@ To see exactly which libraries your command ships before you submit it, dump the
 ```bash
 forge verify-contract ... --show-standard-json-input > standard-input.json
 ```
+
+## Verifying a project that compiles with via-IR
+
+With `via_ir = true`, Solc output for a contract depends on which other sources were in the compilation unit, not only on the contract and its imports. `forge verify-contract` submits just the target's import closure, which is a smaller set than the one your deploy compiled, so the recompiled bytecode can differ.
+
+Run the plain command first. On the project this guidance comes from, thirteen of the fourteen deployed contracts verified with it, and the one that failed was the largest. If it comes back as a bytecode mismatch and your project sets `via_ir = true`, use the build-info path below. The outcome is deterministic for a given source tree: once it fails, it keeps failing until the input changes.
+
+### Verifying a contract that is already deployed
+
+The compilation unit it was deployed from is the one input guaranteed to reproduce its bytecode, so recover that from the build info of the deploy. If you archived that file, use it. Otherwise check out the exact commit you deployed and rebuild, because a source added or removed since the deploy can change the via-IR output:
+
+```bash
+forge build --build-info
+```
+
+```bash
+grep -l '"src/Vault.sol"' out/build-info/*.json
+```
+
+Pick the file that holds your target — the command above finds it — because a project can accumulate several. Then extract the input, dropping `test/` and `script/` so the submission fits the explorer's budget. That is a trim to verify, not to assume: under via-IR even a source your contract never imports can change the output, so confirm the digest still matches before you submit.
+
+```bash
+jq '.input | {language, sources: (.sources | with_entries(select((.key | startswith("test/")) or (.key | startswith("script/")) | not))), settings}' out/build-info/<hash>.json > standard-input.json
+```
+
+Standard JSON accepts only `language`, `sources`, and `settings`, which is why the filter names them; Foundry's build info also keeps `allowPaths`, `basePath`, `includePaths`, and `version` under `.input` for its own use.
+
+The trim is part of the recipe, not a fallback: the Rootstock Explorer caps a Standard JSON submission at 100 sources and 1.5 MiB (1,572,864 bytes) of source content by default, and over either limit it returns `SOURCE_BUDGET_EXCEEDED` instead of compiling. The build this guidance comes from is 127 sources and 1,694,332 bytes; dropping `test/` and `script/` brings it to 77 sources and 1,209,091 bytes.
+
+Submit `standard-input.json` through the **Standard JSON Input** method on the [Rootstock Explorer](/developers/smart-contracts/verify-smart-contracts/rootstock-explorer/).
+
+:::warning[Re-check the bytecode after every change to the source set]
+Under via-IR, changing which sources are in the input changes the compiled output — in both directions. Adding a source the contract never imports can break an input that matched, and an input less than half the size can still match. There is no size rule and no safe direction.
+
+So after every change, recompile and compare against a build you know matches your deploy. No RPC needed:
+
+```bash
+jq -r '.output.contracts["src/Vault.sol"].Vault.evm.bytecode.object' out/build-info/<hash>.json | shasum -a 256
+```
+
+```bash
+solc --standard-json standard-input.json > recompiled.json
+jq -r '.errors // [] | map(select(.severity == "error")) | length' recompiled.json
+jq -r '.contracts["src/Vault.sol"].Vault.evm.bytecode.object' recompiled.json | shasum -a 256
+```
+
+Use the Solc version your deploy used — `solcVersion` in the same build-info file, or the full `metadata.compiler.version` from the artifact — because a different compiler changes the digest on its own. Check the error count first: if the compile failed, `jq` prints `null` and you would be digesting that string rather than any bytecode.
+
+The two digests must be equal; if they differ, put the sources back. Note that `standard-input.json` holds only `language`, `sources`, and `settings` — there is no bytecode inside it to read — and `cast code` returns runtime bytecode, not the creation bytecode these fields hold.
+:::
+
+### Keeping the next deployment verifiable
+
+Redeploying a live contract from a smaller tree is not an option, since its address and state are already in use. What you can do is make the *next* deployment easy to verify: put the filters on the command that compiles your deploy, and keep the build info that run writes.
+
+```bash
+forge script script/Deploy.s.sol --rpc-url <rpc-url> --broadcast --build-info --skip 'test/**'
+```
+
+`--skip` and `--build-info` are accepted by `forge build`, `forge script`, and `forge create`. Two rules go with them:
+
+- **Use globs, not the bare aliases.** `--skip` filters which files are compiled as *targets*, not which files end up in the compilation unit — anything a surviving target imports is pulled back in. The `test` and `script` aliases match only `.t.sol` and `.s.sol`, so a helper like `test/BaseTest.sol` stays in the build and drags its own imports back with it. On the project this guidance comes from, of 127 sources the aliases left 96, `'test/**'` left 83, and `'test/**' 'script/**'` — which you can pass to `forge build` but not to the deploy command — left 55.
+- **Never pass `--skip script` to `forge script`.** It skips the script you are running and the run stops with `Could not find target contract`.
+
+Keeping via-IR off is the other pre-deployment option, and it removes the failure mode rather than working around it: legacy codegen is not sensitive to the source set. That is a decision about your contracts, not about verification — via-IR exists to compile code that legacy codegen cannot.
+
+:::tip[Archive the build info]
+Keep the `out/build-info/<hash>.json` your deploy wrote with your deployment records, and keep it **outside** `out/` — `forge build --force` clears the artifacts folder. It is the input that reproduces the deployed bytecode exactly. Without it you are rebuilding from the commit you deployed, where anything added or removed since then can change the via-IR output. If the code body does reproduce, a metadata footer that differs by the same length still verifies on the Rootstock Explorer, though some other explorers record that as a partial match.
+:::


### PR DESCRIPTION
Related to **DX-1816** (Unverifiable contracts using foundry — Vaults), where we fixed the verification process and agreed to write this up.

> **Stacked on [#525](https://github.com/rsksmart/devportal/pull/525) (DX-1955)** — it edits the same two pages, so this PR targets that branch and GitHub will retarget it to `main` once #525 merges. The diff here is via-IR content only.

## Why

With `via_ir = true`, Solc output for a contract depends on **which other sources were in the compilation unit**, not only on the contract and its imports. `forge verify-contract` submits just the target's import closure, which is smaller than what the deploy compiled — so the recompiled bytecode can differ. Nobody's code is wrong and the verifier is correct; the input simply does not reproduce the deployed bytecode.

It is not the common case, and the doc says so: on the reported project **13 of the 14 deployed contracts verified with the plain command**, and the one that failed was the largest. So: run the plain command first, and reach for build info only on a bytecode mismatch.

## What changed

A new troubleshooting entry and a new section in the Foundry guide, split by the decision the reader is making:

- **Already deployed** — the compilation unit it was deployed from is the one input *guaranteed* to reproduce the bytecode, and it must come from the deploy-time tree (archived build info, or a build of the exact commit deployed). Recovery is a `grep` to pick the right build-info file plus a `jq` filter that keeps only the three keys Standard JSON accepts, dropping `test/` and `script/`.
- **Next deployment** — put `--skip` and `--build-info` on the command that compiles the deploy, and archive that build info outside `out/`, since `forge build --force` clears it. Turning via-IR off is named as the other pre-deploy option.

## Three things worth knowing while reviewing

Measured on the reported project (solc 0.8.34, `via_ir`, optimizer 200), comparing creation-bytecode digests.

1. **The sensitivity is non-monotonic and has no size rule.** 55 sources match, 57 fail, 77/83/96/127 match — adding two OpenZeppelin proxy sources the contract never imports breaks an input that matched. The only rule the doc gives is to re-check after every change to the source set, with a runnable digest comparison.
2. **The trim is required, not a fallback.** The explorer caps a submission at 100 sources and 1.5 MiB of source content, answering `SOURCE_BUDGET_EXCEEDED` without compiling. The full build is 127 sources / 1,694,661 bytes; dropping `test/` and `script/` brings it to 77 / 1,209,404 bytes.
3. **`--skip` needs globs, and never `--skip script` on `forge script`.** It filters compilation *targets*, so anything a surviving target imports comes back: of 127 sources the bare aliases left 96, `'test/**'` left 83, `'test/**' 'script/**'` left 55. `forge script --skip script` skips the script being run and stops with `Could not find target contract`.

## Verification

`yarn build` clean across all four locales; `yarn check-links` reports 0 broken links and 0 broken anchors. The recipe was run end to end offline against the project's real build info: the `jq` filter produces a valid 77-source Standard JSON, solc 0.8.34 compiles it with no errors in ~4.5 s, and its creation-bytecode digest matches the deploy's build info exactly.

