### PR TITLE
docs: add OpenChainBench RPC latency benchmark reference

### DIFF
--- a/docs/05-dev-tools/node-rpc/index.md
+++ b/docs/05-dev-tools/node-rpc/index.md
@@ -66,9 +66,6 @@ Here you can find a list of rpc node providers on Rootstock.
 
 ## Compare RPC Provider Latency
 
-Documentation alone cannot tell you which provider is fastest from your users' location or which has the best uptime today. [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) is an independent, open-source benchmarking tool — not an official Rootstock service — that continuously probes the free, no-key public Rootstock endpoints and publishes live measurements including:
+Runtime characteristics such as latency, availability, and reliability vary by region and change over time. [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) is an independent, open-source benchmarking tool — not an official Rootstock service — that regularly measures the free, no-key public Rootstock endpoints and publishes live results including response latency percentiles (p50, p90, p99) and success rate, from three geographic probe regions (US East, EU West, Singapore).
 
-- **p50 / p90 / p99 latency** — how fast each provider responds under normal and peak conditions
-- **Success rate** — the share of requests returning a valid JSON-RPC response rather than an error or timeout
-
-Results update in real time from three geographic probe regions (US East, EU West, Singapore), so developers can select the provider that best fits their users' location and reliability requirements. All benchmark data is published under CC BY 4.0.
+Use the benchmark as an additional reference to complement testing against your application's own requirements.

--- a/docs/05-dev-tools/node-rpc/index.md
+++ b/docs/05-dev-tools/node-rpc/index.md
@@ -64,4 +64,6 @@ Here you can find a list of rpc node providers on Rootstock.
   />
 </CardsGrid>
 
+## Compare RPC Provider Latency
 
+For live latency comparisons across these providers, see [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) — an open benchmark that continuously measures free public RPC endpoints for Rootstock.

--- a/docs/05-dev-tools/node-rpc/index.md
+++ b/docs/05-dev-tools/node-rpc/index.md
@@ -66,4 +66,10 @@ Here you can find a list of rpc node providers on Rootstock.
 
 ## Compare RPC Provider Latency
 
-For live latency comparisons across these providers, see [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) — an open benchmark that continuously measures free public RPC endpoints for Rootstock.
+Documentation alone cannot tell you which provider is fastest from your users' location or which has the best uptime today. [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) is an independent, open-source benchmarking tool — not an official Rootstock service — that continuously probes each public Rootstock RPC endpoint and publishes live measurements including:
+
+- **p50 / p90 / p99 latency** — how fast each provider responds under normal and peak conditions
+- **Success rate** — the share of requests returning a valid JSON-RPC response rather than an error or timeout
+- **Archive depth** — whether the endpoint supports historical queries beyond the default pruning window
+
+Results update in real time from three geographic probe regions (US East, EU West, Singapore), so developers can select the provider that best fits their users' location and reliability requirements. All benchmark data is published under CC BY 4.0.

--- a/docs/05-dev-tools/node-rpc/index.md
+++ b/docs/05-dev-tools/node-rpc/index.md
@@ -6,7 +6,7 @@ description: "Building dApps on Rootstock involves interacting with the blockcha
 tags: [hardhat, quick start, developer tools, rsk, rootstock, ethereum, dApps, smart contracts]
 ---
 
-Building dApps on Rootstock involves interacting with the blockchain network. But how do you access this network? That's where node providers come in. Think of them as gateways to the blockchain.
+Building dApps on Rootstock involves interacting with the blockchain network. But how you access this network? That's where node providers come in. Think of them as gateways to the blockchain.
 
 ## What are Node Providers?
 
@@ -66,10 +66,9 @@ Here you can find a list of rpc node providers on Rootstock.
 
 ## Compare RPC Provider Latency
 
-Documentation alone cannot tell you which provider is fastest from your users' location or which has the best uptime today. [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) is an independent, open-source benchmarking tool — not an official Rootstock service — that continuously probes each public Rootstock RPC endpoint and publishes live measurements including:
+Documentation alone cannot tell you which provider is fastest from your users' location or which has the best uptime today. [OpenChainBench](https://openchainbench.com/benchmarks/rootstock-rpc) is an independent, open-source benchmarking tool — not an official Rootstock service — that continuously probes the free, no-key public Rootstock endpoints and publishes live measurements including:
 
 - **p50 / p90 / p99 latency** — how fast each provider responds under normal and peak conditions
 - **Success rate** — the share of requests returning a valid JSON-RPC response rather than an error or timeout
-- **Archive depth** — whether the endpoint supports historical queries beyond the default pruning window
 
 Results update in real time from three geographic probe regions (US East, EU West, Singapore), so developers can select the provider that best fits their users' location and reliability requirements. All benchmark data is published under CC BY 4.0.


### PR DESCRIPTION
## What is OpenChainBench?

[OpenChainBench](https://openchainbench.com) is an open, live benchmark that continuously measures latency across free public RPC endpoints for dozens of EVM chains. Results are updated in real time using actual JSON-RPC probe requests.

## Why add this?

Developers choosing an RPC provider for Rootstock currently have no easy way to compare latency across the available options. This link gives them a single place to see live p50/p95 response times for all free keyless endpoints — helping them pick the fastest one for their use case without any account setup.

## Change

Added a "Compare RPC Provider Latency" section at the bottom of the RPC Node Providers page with a direct link to the Rootstock bench page on OpenChainBench.