### PR TITLE
fix: clear afdocs round-2 fence and content-start fails

### DIFF
--- a/docs/04-resources/05-port-to-rootstock/ethereum-dapp.md
+++ b/docs/04-resources/05-port-to-rootstock/ethereum-dapp.md
@@ -127,14 +127,15 @@ Before you begin, ensure that you have the following:
   ```
 
   At this point, your `hardhat.config.ts` should look like this:
-  ```typescript
-    import { HardhatUserConfig } from "hardhat/config";
-    import "@nomicfoundation/hardhat-toolbox";
-    import "@nomicfoundation/hardhat-ignition-ethers";
 
-    const config: HardhatUserConfig = {
-      solidity: "0.8.30",
-  };
+```typescript
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+import "@nomicfoundation/hardhat-ignition-ethers";
+
+const config: HardhatUserConfig = {
+  solidity: "0.8.30",
+};
 
 export default config;
 ```
@@ -145,22 +146,17 @@ To configure the Rootstock networks, you'll need an RPC URL for both mainnet and
 
 To get the RPCs, go to the [RPC API dashboard from Rootstock Labs](https://dashboard.rpc.rootstock.io/dashboard) create an account if you don't have one, and get an API key for Rootstock testnet or Rootstock mainnet.
 
+Mainnet RPC URL should look similar to this:
 
-````mdx-code-block
-<Tabs>
-  <TabItem value="contribute" label="Mainnet RPC URL should look similar to this:" default>
-    ```
-https://rpc.mainnet.rootstock.io/<API-KEY>
+```text
+https://rpc.mainnet.rootstock.io/YOUR_API_KEY
 ```
-  </TabItem>
-  <TabItem value="contest" label="Testnet RPC URL should look similar to this:">
- ```
-https://rpc.testnet.rootstock.io/<API-KEY>
-```
-  </TabItem>
 
-</Tabs>
-````
+Testnet RPC URL should look similar to this:
+
+```text
+https://rpc.testnet.rootstock.io/YOUR_API_KEY
+```
 
 The next step is to retrieve your private key. If you don't know how to get the private key to your wallet, here's a [tutorial](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-export-an-accounts-private-key/) on [Metamask](https://metamask.io/).
 
@@ -219,13 +215,13 @@ const config: HardhatUserConfig = {
   networks: {
     // Mainnet configuration
     rskMainnet: {
-      url: "https://rpc.mainnet.rootstock.io/<API-KEY>",
+      url: "https://rpc.mainnet.rootstock.io/YOUR_API_KEY",
       accounts: [process.env.PRIVATE_KEY],
     },
 
     // Testnet configuration
     rskTestnet: {
-      url: "https://rpc.testnet.rootstock.io/<API-KEY>",
+      url: "https://rpc.testnet.rootstock.io/YOUR_API_KEY",
       accounts: [process.env.PRIVATE_KEY],
     },
   },
@@ -233,7 +229,7 @@ const config: HardhatUserConfig = {
 
 export default config;
 ```
-Replace `<API-KEY>` with your actual API keys obtained from the Rootstock Labs dashboard. Also, store your private key securely (e.g., in a `.env` file).
+Replace `YOUR_API_KEY` with your actual API keys obtained from the Rootstock Labs dashboard. Also, store your private key securely (for example in a `.env` file).
 
 ### Copy Ethereum Contract Code and Tests
 
@@ -337,7 +333,7 @@ npx hardhat test
 
 The test results will show whether your contract behaves as expected. You should see something like this:
 
-```s
+```text
 SimpleStorage
     Deployment
       ✔ Should deploy and initialize favoriteNumber to 0

--- a/docs/04-resources/06-guides/powpeg-app/advanced-operations/supported-addresses.md
+++ b/docs/04-resources/06-guides/powpeg-app/advanced-operations/supported-addresses.md
@@ -6,13 +6,50 @@ description: "See supported addresses on the PowPeg App"
 tags: [powpeg app, peg-in, peg-out, bridge, rsk, rootstock]
 ---
 
-The following address types are supported by the PowPeg App.
+The PowPeg App accepts common Bitcoin address formats for peg-in and related flows. Use an address type your wallet can generate and that matches the network you are using (Bitcoin mainnet or testnet).
 
-- Segwit:
-A SegWit address starts with the number 3 and has more elaborated functionality than a legacy address. Types include P2SH-P2WPKH and P2SH-P2WSH.
+## Address types
 
-- Native segwit:
-Also known as Bech32 address, native SegWit looks different from the P2-styles as it starts with bc1.
+### SegWit (P2SH)
 
-- Legacy address:
-These addresses are the original BTC addresses. It uses a special script hash function called P2PKH (Pay-to-Pubkey Hash) address and starts with the number 1.
+A SegWit address wrapped in P2SH starts with `3` on Bitcoin mainnet. Types include P2SH-P2WPKH and P2SH-P2WSH. Many hardware and software wallets still expose this format as the default SegWit option.
+
+Example shape (do not send funds to sample strings):
+
+```text
+3J98t1WpEZ73CNmYviecrnyiWrnqRhWNLy
+```
+
+### Native SegWit (Bech32)
+
+Native SegWit, also called Bech32, starts with `bc1` on Bitcoin mainnet. Prefer this format when your wallet supports it. Fees are typically lower than legacy or P2SH-wrapped SegWit for the same spend.
+
+Example shape:
+
+```text
+bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq
+```
+
+On Bitcoin testnet, native SegWit addresses often start with `tb1` instead of `bc1`. Confirm the prefix your wallet shows before you paste an address into the PowPeg App.
+
+### Legacy (P2PKH)
+
+Legacy addresses use P2PKH and start with `1` on Bitcoin mainnet. They remain supported, but they usually cost more to spend than SegWit formats.
+
+Example shape:
+
+```text
+1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
+```
+
+## Practical notes
+
+- Match network and address: a mainnet `bc1` / `3` / `1` address is not valid on testnet, and testnet prefixes are not valid on mainnet.
+- Peg-in deposits go to a Bitcoin address the PowPeg App derives for your session. Peg-out destinations are Rootstock (rBTC) addresses in your EVM wallet, not Bitcoin address types from this list.
+- If an address is rejected, check the prefix, network, and that the wallet exported a standard Base58 or Bech32 string with no extra spaces.
+
+## Related pages
+
+- [Supported wallets](/resources/guides/powpeg-app/advanced-operations/supported-wallets/)
+- [Supported browsers](/resources/guides/powpeg-app/advanced-operations/supported-browsers/)
+- [PowPeg App overview](/resources/guides/powpeg-app/overview/)


### PR DESCRIPTION
## Summary
- Fix unclosed markdown fences on the Port an Ethereum dApp guide by flattening nested Tabs and replacing `<API-KEY>` placeholders that JSX-parsed out of served `.md`.
- Expand PowPeg supported-addresses with examples and practical notes so `content-start-position` no longer hard-fails (~52% chrome-heavy short page).
- Follow-up to Phase 1A agent-readiness work in #532 (and the related llms/fence pass in #535).

## Test plan
- [ ] `yarn build` succeeds
- [ ] Served `/resources/port-to-rootstock/ethereum-dapp.md` has balanced fences and includes `YOUR_API_KEY` URL examples
- [ ] `/resources/guides/powpeg-app/advanced-operations/supported-addresses` has expanded sections
- [ ] `npx afdocs check <preview-or-prod> --fixes --verbose` shows fence fail gone and no content-start hard fail on supported-addresses (parity may still fail)


Made with [Cursor](https://cursor.com)