### PR TITLE
fix: stack the chat bubble above the accessiBe accessibility trigger (DX-2085)

### DIFF
--- a/src/theme/Navbar/FlowiseChatbot/index.js
+++ b/src/theme/Navbar/FlowiseChatbot/index.js
@@ -35,7 +35,15 @@ function buildTheme(isDark) {
     button: {
       backgroundColor: t.brand,
       right: 20,
-      bottom: 20,
+      // Stacked ABOVE the accessiBe trigger, which also sits bottom-right at
+      // offset 20/20 with a 48px medium trigger and z-index 2147483647 — it was
+      // covering this bubble completely on desktop and partially on mobile.
+      // accessiBe's placement comes from its remote dashboard config
+      // (cdn.acsbapp.com/config/<domain>/config.json), NOT from the acsbJS.init()
+      // options in src/components/AccessibeWidget — so it can only be moved from
+      // the accessiBe admin, and this side is the one we control in code.
+      // 20 (its offset) + 48 (its size) + 20 (gap) = 88.
+      bottom: 88,
       size: 48,
       iconColor: 'white',
     },


### PR DESCRIPTION
Fixes DX-2085.

## Problem

The Flowise chat bubble and the accessiBe accessibility trigger are both pinned to the bottom-right corner with the same 20px offset and the same 48px size, so they occupy the same box. accessiBe renders at `z-index: 2147483647`, so it always paints on top.

Reproduced on https://dev.rootstock.io/ with Chromium 149:

| Viewport | Result |
| --- | --- |
| Desktop 1440x900 | Chat bubble **100% covered** by the accessibility button |
| Mobile 390x844 (iPhone 14) | Chat bubble partially covered |

On desktop the chatbot ends up with no discoverable entry point outside the navbar "Ask Rootstock" button.

## Root cause

Both widgets claim the same corner:

- **Flowise bubble** — `src/theme/Navbar/FlowiseChatbot/index.js`, theme `button: { right: 20, bottom: 20, size: 48 }`.
- **accessiBe trigger** — bottom-right, offset 20/20, size `medium` (48px), at `z-index: 2147483647`.

Worth flagging for future work: **the `acsbJS.init()` options in `src/components/AccessibeWidget/index.js` are inert.** accessiBe takes its real settings from a remote per-domain config — `https://cdn.acsbapp.com/config/dev.rootstock.io/config.json` — which declares `triggerPositionX: "right"`, offset 20/20, size `medium`, `triggerColor: #146FF8`, and no mobile block. The repo passes `left` and `#000` for desktop, yet the live trigger renders bottom-right and blue in every viewport, matching the remote config on every observable key. So editing that file changes nothing, and raising the bubble's z-index cannot beat 2147483647 either.

## Fix

Move the side we actually control in code — stack the chat bubble above the accessibility trigger: `bottom: 20` → `bottom: 88` (20 offset + 48 trigger + 20 gap).

## Verification

Measured against the geometry accessiBe's remote config declares:

| Viewport | Chat bubble | Accessibility trigger | Gap | Overlap |
| --- | --- | --- | --- | --- |
| Mobile 390x844 | y 708–756 | y 776–824 | 20px | none |
| Desktop 1440x900 | y 764–812 | y 832–880 | 20px | none |

Chat window opened in both viewports: still full-screen on mobile, 400x738 on desktop, not clipped, no console errors.

**Caveat for reviewers testing locally:** accessiBe does *not* render on `localhost` — its `config.json` 404s for unlicensed domains. Check this on a deployed environment, or inject a 48px stand-in at `right: 20 / bottom: 20` in the console.

## Out of scope / follow-up

The cleaner layout — one control per corner — means moving the accessibility trigger to the left, which can only be done from the **accessiBe admin dashboard**, not from this repo. If that happens, the bubble can go back to `bottom: 20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
